### PR TITLE
[BE-16] feat: 논리 삭제 및 생성/수정 시간 기록을 위한 BaseEntity 구현

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/entity/BaseEntity.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/entity/BaseEntity.java
@@ -1,5 +1,39 @@
 package com.deokhugam.deokhugam_server.global.entity;
 
-public class BaseEntity {
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(nullable = false)
+  private boolean isDeleted = false;
+
+  private LocalDateTime deletedAt; // 삭체 시점 기록 필드 추가
+
+  public void delete() {
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now(); // 삭제하는 순간의 시간 기록
+  }
+
+  public void undoDelete() {
+    this.isDeleted = false;
+    this.deletedAt = null; // 복구하면 삭제 시간 초기화
+  }
 }


### PR DESCRIPTION
## global/BaseEntity 구현

노션 링크: https://www.notion.so/global-BaseEntity-3506e443c2888140b8a0e31d244cb6c2?source=copy_link

📋 작업 개요
모든 엔티티에서 공통으로 사용하는 식별자(ID) 및 메타데이터 필드를 중복 선언 없이 관리하기 위한 공통 부모 클래스 설계 및 구현

✨ 주요 기능
- 식별자 표준화: 모든 엔티티에 UUID 방식의 PK 적용
- JPA Auditing: 생성 시각(createdAt) 및 수정 시각(updatedAt) 자동 기록
- 논리 삭제(Soft Delete) 지원: 삭제 여부를 판단하는 isDeleted 필드 공통화