### PR TITLE
[BE-10] feat: global/cursorpage 구현

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/entity/BaseEntity.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/entity/BaseEntity.java
@@ -1,5 +1,39 @@
 package com.deokhugam.deokhugam_server.global.entity;
 
-public class BaseEntity {
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(nullable = false)
+  private boolean isDeleted = false;
+
+  private LocalDateTime deletedAt; // 삭체 시점 기록 필드 추가
+
+  public void delete() {
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now(); // 삭제하는 순간의 시간 기록
+  }
+
+  public void undoDelete() {
+    this.isDeleted = false;
+    this.deletedAt = null; // 복구하면 삭제 시간 초기화
+  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/response/CursorPageResponse.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/response/CursorPageResponse.java
@@ -1,5 +1,13 @@
 package com.deokhugam.deokhugam_server.global.response;
 
-public class CursorPageResponse {
+import java.time.LocalDateTime;
+import java.util.List;
 
-}
+public record CursorPageResponse<T>(
+    List<T> content,        // 실제 데이터 리스트
+    String nextCursor,      // 다음 조회를 위한 커서 ID
+    LocalDateTime nextAfter, // 다음 조회를 위한 시간 기준점
+    int size,               // 현재 페이지에 담긴 개수
+    long totalElements,     // 전체 데이터 개수
+    boolean hasNext         // 다음 페이지가 더 있는지 여부
+) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/util/CursorPageUtil.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/util/CursorPageUtil.java
@@ -1,5 +1,54 @@
 package com.deokhugam.deokhugam_server.global.util;
 
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+
 public class CursorPageUtil {
 
+  /**
+   * DB에서 가져온 리스트를 커서 페이지 응답 객체로 변환합니다.
+   * * @param items          DB에서 조회한 결과 리스트 (보통 요청한 limit보다 +1해서 가져옴)
+   * @param limit          클라이언트가 요청한 한 페이지 크기
+   * @param totalElements  전체 데이터 개수
+   * @param cursorExtractor 엔티티에서 ID(커서)를 뽑아내는 함수
+   * @param timeExtractor   엔티티에서 시간(after)을 뽑아내는 함수
+   */
+  public static <T, R> CursorPageResponse<R> toResponse(
+      List<T> items,
+      int limit,
+      long totalElements,
+      Function<T, R> mapper,
+      Function<T, String> cursorExtractor, // 커서값 추출 로직
+      Function<T, LocalDateTime> timeExtractor // 시간값 추출 로직
+  ) {
+    // 1. 다음 페이지가 있는지 확인
+    boolean hasNext = items.size() > limit;
+
+    // 2. 실제 페이지 크기에 맞춰 데이터 자르기
+    List<T> subList = hasNext ? items.subList(0, limit) : items;
+
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+
+    // 3. 다음 페이지가 있다면, 마지막 데이터에서 커서 정보 추출
+    if (hasNext && !subList.isEmpty()) {
+      T lastItem = subList.get(subList.size() - 1);
+      nextCursor = cursorExtractor.apply(lastItem);
+      nextAfter = timeExtractor.apply(lastItem);
+    }
+
+    // 4. Entity 리스트를 DTO 리스트로 변환
+    List<R> content = subList.stream().map(mapper).toList();
+
+    return new CursorPageResponse<>(
+        content,
+        nextCursor,
+        nextAfter,
+        content.size(),
+        totalElements,
+        hasNext
+    );
+  }
 }


### PR DESCRIPTION
## global/CursorPagination 구현

노션 링크: https://www.notion.so/global-cursorpage-3506e443c28881aa9728c21b0934e764?source=copy_link

📋 작업 개요
도메인 전반에서 공통으로 사용할 수 있는 커서 기반 페이징 응답 객체(CursorPageResponse) 및 변환 유틸리티(CursorPageUtil) 구현

✨ 주요 기능
- limit + 1 전략: DB 조회 시 limit보다 하나 더 가져와 별도 count 쿼리 없이 다음 페이지 존재 여부 판단
- 범용성 확보: 제네릭(T, R) 및 함수형 인터페이스를 활용하여 어떤 엔티티/DTO 구조에서도 재사용 가능
- 커서 자동 추출: 리스트의 마지막 요소로부터 다음 조회를 위한 커서와 기준 시간을 자동으로 계산하여 응답