### PR TITLE
[BE-9] feat: 프로젝트 공통 예외 처리 시스템(Global Exception) 구축

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/DeokhugamException.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/DeokhugamException.java
@@ -1,8 +1,13 @@
 package com.deokhugam.deokhugam_server.global.exception;
 
-public class DeokhugamException extends RuntimeException {
+import lombok.Getter;
 
-  public DeokhugamException(String message) {
-    super(message);
+@Getter
+public class DeokhugamException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public DeokhugamException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/ErrorCode.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/ErrorCode.java
@@ -1,5 +1,60 @@
 package com.deokhugam.deokhugam_server.global.exception;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
 
+  // [COMMON] 공통 에러 - 명세서 400, 500 대응
+  INVALID_INPUT_VALUE(400, "C001", "잘못된 요청 (입력값 검증 실패)"),
+  INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
+  METHOD_NOT_ALLOWED(405, "C003", "허용되지 않은 메소드입니다."),
+  HANDLE_ACCESS_DENIED(403, "C004", "접근 권한이 없습니다."),
+
+  /*
+   * [USER] 사용자 관리
+   * 명세서 /api/users, /api/users/login 대응
+   */
+  LOGIN_FAILED(401, "U101", "로그인 실패 (이메일 또는 비밀번호 불일치)"),
+  DUPLICATE_EMAIL(409, "U102", "이메일 중복"),
+  USER_NOT_FOUND(404, "U103", "사용자 정보 없음"),
+
+  /*
+   * [BOOK] 도서 관리
+   * 명세서 /api/books 대응
+   */
+  BOOK_NOT_FOUND(404, "B201", "도서 정보 없음"),
+  DUPLICATE_ISBN(409, "B202", "ISBN 중복"),
+
+  // [REVIEW] 리뷰 관리
+  // 명세서 /api/reviews 대응
+  REVIEW_NOT_FOUND(404, "R301", "리뷰 정보 없음"),
+  ALREADY_REVIEWED(409, "R302", "이미 작성된 리뷰 존재"),
+  NOT_REVIEW_OWNER(403, "R303", "리뷰 수정/삭제 권한 없음"),
+
+  // [COMMENT] 댓글 관리
+  // 명세서 /api/comments 대응
+  COMMENT_NOT_FOUND(404, "M401", "댓글 정보 없음"),
+  NOT_COMMENT_OWNER(403, "M402", "댓글 수정/삭제 권한 없음"),
+  COMMENT_BAD_REQUEST(400, "M403", "잘못된 요청 (리뷰 ID 누락 등)"),
+
+  /*
+   * [NOTIFICATION] 알림 관리
+   * 명세서 /api/notifications 대응
+   */
+  NOTIFICATION_NOT_FOUND(404, "N501", "알림 정보 없음"),
+  NOT_NOTIFICATION_OWNER(403, "N502", "알림 수정 권한 없음"),
+
+  /*
+   * [DASHBOARD] 대시보드
+   * 명세서 /api/users/power, /api/reviews/popular 대응
+   */
+  INVALID_PERIOD(400, "D601", "잘못된 요청 (랭킹 기간 오류 등)")
+  ;
+
+  private final int status;
+  private final String code;
+  private final String message;
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/ErrorResponse.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/ErrorResponse.java
@@ -1,5 +1,15 @@
 package com.deokhugam.deokhugam_server.global.exception;
 
-public record ErrorResponse() {
-
+public record ErrorResponse(
+    int status,
+    String code,
+    String message
+) {
+  public static ErrorResponse of(ErrorCode errorCode) {
+    return new ErrorResponse(
+        errorCode.getStatus(),
+        errorCode.getCode(),
+        errorCode.getMessage()
+    );
+  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/GlobalExceptionHandler.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,44 @@
 package com.deokhugam.deokhugam_server.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  // 1. 비즈니스 로직 예외 처리
+  @ExceptionHandler(DeokhugamException.class)
+  protected ResponseEntity<ErrorResponse> handleDeokhugamException(DeokhugamException e) {
+    log.error("DeokhugamException: {}", e.getErrorCode().getMessage());
+
+    ErrorCode errorCode = e.getErrorCode();
+    ErrorResponse response = ErrorResponse.of(errorCode);
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+  }
+
+  // 2. Bean Validation 예외 처리 (명세서 400 대응)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    log.error("MethodArgumentNotValidException: {}", e.getMessage());
+
+    ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  // 3. 그 외 예상치 못한 시스템 예외 (명세서 500 대응)
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("Unhandled Exception: ", e);
+
+    ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }


### PR DESCRIPTION
## global/Exception 구현

노션 링크: https://www.notion.so/global-exception-3506e443c2888126af52c5c3e8869c1f?source=copy_link

📋 작업 개요
프로젝트 전반에서 발생하는 예외를 표준화된 규격으로 처리하기 위한 **글로벌 예외 핸들링 인프라**를 구축했습니다. API 명세서의 상태 코드와 요구사항 정의서의 비즈니스 로직을 모두 반영했습니다.

✨ 주요 기능
* **`ErrorCode.java`**: 시스템 전체 에러 코드를 관리하는 Enum입니다.
    * 공통(C), 유저(U), 도서(B), 리뷰(R), 댓글(M), 알림(N), 대시보드(D) 구역을 분리하여 관리합니다.
    * **유효성 검사 실패(400)** , **로그인 실패(401)** , **권한 확인(403)** , **중복 체크(409)**등 명세서의 상태 코드를 엄격히 준수합니다.
* **`DeokhugamException.java`**: 비즈니스 로직 에러를 실어 나르는 커스텀 실행 예외(Runtime Exception) 클래스입니다.
* **`ErrorResponse.java`**: 프론트엔드와 약속한 에러 응답 패킷 규격입니다. (status, code, message)
* **`GlobalExceptionHandler.java`**: 중앙 제어 장치로, 모든 예외를 낚아채 표준 응답으로 변환합니다.
    * Bean Validation 실패(400) 및 서버 내부 오류(500)를 포함한 모든 예외를 핸들링하며, 로깅 및 MDC 설정을 위한 기반을 마련했습니다.

참고 사항
* **논리 삭제 및 권한 검사**: PDF 요구사항에 명시된 본인 작성 여부 확인 및 데이터 부재 시의 예외 상황들을 모두 `ErrorCode`에 반영했습니다.
* **협업 가이드**: 각 도메인 담당자는 `ErrorCode`의 본인 구역에 에러 정의를 추가하여 즉시 사용할 수 있습니다.