### PR TITLE
[BE-109] feat: 공통 응답 규격을 위한 ApiResponse 클래스 구현

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/response/ApiResponse.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/response/ApiResponse.java
@@ -1,5 +1,30 @@
 package com.deokhugam.deokhugam_server.global.response;
 
-public class ApiResponse {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+  private final boolean success;
+  private final int status; // 상태 코드 숫자 (예: 201, 204) 추가
+  private final T data;
+  private final String message;
+
+  // 성공 응답 (데이터 + 상태 코드)
+  public static <T> ApiResponse<T> success(T data, HttpStatus status) {
+    return new ApiResponse<>(true, status.value(), data, status.getReasonPhrase());
+  }
+
+  // 성공 응답 (데이터만 - 기본 200 OK)
+  public static <T> ApiResponse<T> success(T data) {
+    return new ApiResponse<>(true, 200, data, "Success");
+  }
+
+  // 실패 응답
+  public static <T> ApiResponse<T> error(String message, HttpStatus status) {
+    return new ApiResponse<>(false, status.value(), null, message);
+  }
 }


### PR DESCRIPTION
## global/Response 구현

노션 링크: https://www.notion.so/ApiResponse-3516e443c28880a4ae51c311a23e05c3?source=copy_link

📋 작업 개요
프로젝트 전체의 API 응답 형식을 통일하고 클라이언트와의 통신 정합성을 확보하기 위한 공통 응답 객체(ApiResponse) 구현

✨ 주요 기능
- 제네릭 타입(T) 지원: 도메인 및 데이터 타입에 관계없이 다양한 반환 데이터를 안전하게 캡슐화
- 표준 응답 규격화: success, status, data, message로 구성된 일관된 필드 구조 제공
- 정적 팩토리 메서드: success(), error() 메서드 제공을 통해 컨트롤러 내 응답 객체 생성 가독성 향상

💡 사용 예시 (Usage)
```java
// 1. 성공 응답 (200 OK)
return ApiResponse.success(userDto);

// 2. 성공 응답 (201 Created)
return ApiResponse.success(bookDto, HttpStatus.CREATED);

// 3. 실패 응답 (GlobalExceptionHandler에서 내부적으로 사용)
return ApiResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
```