### PR TITLE
[BE-15] feat: Review 도메인 핵심 비즈니스 로직 및 API 구현(Service, Controller)

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/controller/ReviewController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/controller/ReviewController.java
@@ -1,0 +1,77 @@
+package com.deokhugam.deokhugam_server.domain.review.controller;
+
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewCreateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewSearchRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
+import com.deokhugam.deokhugam_server.domain.review.service.ReviewService;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "리뷰 관리", description = "리뷰 관련 API")
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+  private final ReviewService reviewService;
+
+  @Operation(summary = "리뷰 등록", description = "새로운 리뷰를 등록합니다.")
+  @PostMapping
+  public ResponseEntity<ReviewDto> createReview(@Valid @RequestBody ReviewCreateRequest request) {
+    ReviewDto response = reviewService.createReview(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "리뷰 상세 정보 조회", description = "리뷰 ID로 상세 정보를 조회합니다.")
+  @GetMapping("/{reviewId}")
+  public ResponseEntity<ReviewDto> getReview(
+      @PathVariable UUID reviewId,
+      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) { // 명세서 헤더 규격 준수
+
+    ReviewDto response = reviewService.getReview(reviewId, requestUserId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "리뷰 목록 조회", description = "검색 조건에 맞는 리뷰 목록을 조회합니다.")
+  @GetMapping
+  public ResponseEntity<CursorPageResponse<ReviewDto>> searchReviews(
+      @Valid ReviewSearchRequest request,
+      @RequestHeader("Deokhugam-Request-User-ID") UUID headerUserId) {
+
+    // 헤더의 유저 ID를 검색 조건에 주입
+    request.setRequestUserId(headerUserId);
+
+    CursorPageResponse<ReviewDto> response = reviewService.searchReviews(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "리뷰 수정", description = "본인이 작성한 리뷰를 수정합니다.")
+  @PatchMapping("/{reviewId}")
+  public ResponseEntity<ReviewDto> updateReview(
+      @PathVariable UUID reviewId,
+      @Valid @RequestBody ReviewUpdateRequest request,
+      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+    ReviewDto response = reviewService.updateReview(reviewId, request, requestUserId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "리뷰 논리 삭제", description = "본인이 작성한 리뷰를 논리적으로 삭제합니다.")
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<Void> deleteReview(
+      @PathVariable UUID reviewId,
+      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+    reviewService.deleteReview(reviewId, requestUserId);
+    return ResponseEntity.noContent().build(); // 204 No Content
+  }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewLikedEvent.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewLikedEvent.java
@@ -1,0 +1,10 @@
+package com.deokhugam.deokhugam_server.domain.review.event;
+
+import java.util.UUID;
+
+public record ReviewLikedEvent(
+    UUID reviewId,      // 좋아요가 달린 리뷰 ID
+    UUID likerId,       // 좋아요를 누른 사용자 ID
+    UUID targetUserId,  // 알림을 받을 리뷰 작성자 ID
+    String reviewContent // 알림 메시지에 표시할 리뷰 내용 요약
+) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewRankedEvent.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewRankedEvent.java
@@ -1,0 +1,15 @@
+package com.deokhugam.deokhugam_server.domain.review.event;
+
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.util.UUID;
+
+/**
+ * 리뷰가 인기 순위 상위권(10위 내)에 진입했을 때 발생하는 이벤트입니다.
+ */
+public record ReviewRankedEvent(
+    UUID reviewId,
+    UUID userId,        // 알림을 받을 리뷰 작성자 ID
+    Period period,      // 일간, 주간, 월간 등 [cite: 169]
+    int rank,           // 달성한 순위
+    String reviewContent
+) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/mapper/ReviewMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/mapper/ReviewMapper.java
@@ -1,0 +1,23 @@
+package com.deokhugam.deokhugam_server.domain.review.mapper;
+
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewCreateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ReviewMapper {
+
+  // Request DTO -> Entity (UUID 기반이라 직접 매핑됨)
+  Review toEntity(ReviewCreateRequest request);
+
+  // Entity -> Response DTO
+  // bookTitle, userNickname 등은 서비스에서 fetch해온 값을 넘겨받아 매핑
+  @Mapping(target = "bookTitle", source = "bookTitle")
+  @Mapping(target = "userNickname", source = "userNickname")
+  @Mapping(target = "bookThumbnailUrl", source = "bookThumbnailUrl")
+  @Mapping(target = "likedByMe", source = "likedByMe")
+  ReviewDto toDto(Review review, String bookTitle, String bookThumbnailUrl, String userNickname, boolean likedByMe);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewService.java
@@ -1,0 +1,25 @@
+package com.deokhugam.deokhugam_server.domain.review.service;
+
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewCreateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewSearchRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import java.util.UUID;
+
+public interface ReviewService {
+  // 리뷰 등록
+  ReviewDto createReview(ReviewCreateRequest request);
+
+  // 리뷰 상세 조회
+  ReviewDto getReview(UUID reviewId, UUID requestUserId);
+
+  // 리뷰 목록 조회 (검색 및 페이지네이션)
+  CursorPageResponse<ReviewDto> searchReviews(ReviewSearchRequest request);
+
+  // 리뷰 수정
+  ReviewDto updateReview(UUID reviewId, ReviewUpdateRequest request, UUID requestUserId);
+
+  // 리뷰 삭제 (논리 삭제)
+  void deleteReview(UUID reviewId, UUID requestUserId);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,141 @@
+package com.deokhugam.deokhugam_server.domain.review.service;
+
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
+import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewCreateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewSearchRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.mapper.ReviewMapper;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewLikeRepository;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewServiceImpl implements ReviewService {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewLikeRepository reviewLikeRepository;
+  private final BookRepository bookRepository;
+  private final UserRepository userRepository;
+  private final ReviewMapper reviewMapper;
+
+  @Override
+  @Transactional
+  public ReviewDto createReview(ReviewCreateRequest request) {
+    // 1. 도서 및 사용자 존재 여부 확인
+    Book book = bookRepository.findById(request.bookId())
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
+    User user = userRepository.findById(request.userId())
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.USER_NOT_FOUND));
+
+    // 2. 도서 별 1개의 리뷰만 등록 가능 여부 체크
+    if (reviewRepository.existsByBookIdAndUserIdAndIsDeletedFalse(request.bookId(), request.userId())) {
+      throw new DeokhugamException(ErrorCode.ALREADY_REVIEWED); // ErrorCode 명칭 수정
+    }
+
+    // 3. 리뷰 저장
+    Review review = reviewMapper.toEntity(request);
+    Review savedReview = reviewRepository.save(review);
+
+    return reviewMapper.toDto(savedReview, book.getTitle(), book.getImageUrl(), user.getNickname(), false);
+  }
+
+  @Override
+  public ReviewDto getReview(UUID reviewId, UUID requestUserId) {
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
+
+    Book book = bookRepository.findById(review.getBookId())
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
+    User user = userRepository.findById(review.getUserId())
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.USER_NOT_FOUND));
+
+    // 요청자의 좋아요 여부 포함
+    boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(reviewId, requestUserId);
+
+    return reviewMapper.toDto(review, book.getTitle(), book.getImageUrl(), user.getNickname(), likedByMe);
+  }
+
+  @Override
+  public CursorPageResponse<ReviewDto> searchReviews(ReviewSearchRequest request) {
+    // QueryDSL을 통한 목록 조회
+    List<Review> reviews = reviewRepository.searchReviews(request);
+
+    // 다음 페이지 존재 여부 확인 (limit+1 fetch 전략)
+    boolean hasNext = reviews.size() > request.getLimit();
+    if (hasNext) {
+      reviews.remove(reviews.size() - 1);
+    }
+
+    List<ReviewDto> content = reviews.stream().map(review -> {
+      Book book = bookRepository.findById(review.getBookId()).orElse(null);
+      User user = userRepository.findById(review.getUserId()).orElse(null);
+      boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(review.getId(), request.getRequestUserId());
+
+      return reviewMapper.toDto(
+          review,
+          book != null ? book.getTitle() : "알 수 없는 도서",
+          book != null ? book.getImageUrl() : null,
+          user != null ? user.getNickname() : "알 수 없는 사용자",
+          likedByMe
+      );
+    }).collect(Collectors.toList());
+
+    // 커서 및 보조 커서 설정
+    String nextCursor = hasNext ? reviews.get(reviews.size() - 1).getId().toString() : null;
+    java.time.LocalDateTime nextAfter = hasNext ? reviews.get(reviews.size() - 1).getCreatedAt() : null;
+
+    return new CursorPageResponse<>(content, nextCursor, nextAfter, request.getLimit(), 0L, hasNext);
+  }
+
+  @Override
+  @Transactional
+  public ReviewDto updateReview(UUID reviewId, ReviewUpdateRequest request, UUID requestUserId) {
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
+
+    // 본인이 작성한 리뷰만 수정 가능
+    if (!review.getUserId().equals(requestUserId)) {
+      throw new DeokhugamException(ErrorCode.NOT_REVIEW_OWNER);
+    }
+
+    review.update(request.content(), request.rating());
+
+    // 수정 후 응답 데이터 구성
+    Book book = bookRepository.findById(review.getBookId()).orElse(null);
+    User user = userRepository.findById(review.getUserId()).orElse(null);
+    boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(reviewId, requestUserId);
+
+    return reviewMapper.toDto(review, book.getTitle(), book.getImageUrl(), user.getNickname(), likedByMe);
+  }
+
+  @Override
+  @Transactional
+  public void deleteReview(UUID reviewId, UUID requestUserId) {
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
+
+    // 본인이 작성한 리뷰만 삭제 가능
+    if (!review.getUserId().equals(requestUserId)) {
+      throw new DeokhugamException(ErrorCode.NOT_REVIEW_OWNER); // ErrorCode 명칭 수정
+    }
+
+    // 논리 삭제 처리
+    review.delete();
+  }
+}


### PR DESCRIPTION
## domain/Review 서비스 및 컨트롤러 구현

노션 링크: https://www.notion.so/Review-API-Service-Controller-3506e443c288819c8c3fd62d7f738dc0?source=copy_link

📋 작업 개요
리뷰 도메인의 핵심 비즈니스 로직 구현 및 RESTful API 엔드포인트 구축

✨ 주요 기능
- 매퍼 & 이벤트: MapStruct를 통한 DTO-Entity 변환 최적화 및 알림 연동을 위한 도메인 이벤트(Liked, Ranked) 정의
- 서비스 로직: '도서별 1인 1리뷰' 제약 조건 반영, 논리 삭제(Soft Delete) 도입 및 작성자 권한 검증 로직 구현
- 컨트롤러 레이어: 명세서 규격에 맞춘 CRUD API 제공 및 Deokhugam-Request-User-ID 헤더를 통한 사용자 식별
