### PR TITLE
[BE-33] chroe: CI/CD 파이프라인 구축 (GitHub Actions)

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,28 @@
+---
+name: "Task"
+about: "Task Tracker 작업 등록"
+title: "[BE-{ID}] 작업 제목"
+labels: ""
+assignees: ""
+---
+
+## 📋 작업 개요
+
+<!-- 작업 내용을 간략히 설명해주세요 -->
+
+## 🔗 Notion Task 링크
+
+<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
+- Notion:
+
+## 📌 작업 유형
+
+- [ ] Feature
+- [ ] Fix
+- [ ] Refactor
+- [ ] Docs
+- [ ] Chore
+
+## ✅ 체크리스트
+
+- [ ] Task Tracker의 GitHub Issue 필드에 이 Issue URL 기입

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## 📋 관련 Issue
+
+Closes #{issue_number}
+
+## 🔗 Notion Task 링크
+<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
+- Notion:
+
+## 🛠️ 작업 내용
+<!-- 변경 사항을 간략히 설명해주세요 -->
+
+## 🧪 테스트
+- [ ] 로컬 테스트 완료
+- [ ] API 동작 확인
+
+## ✅ 체크리스트
+- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
+- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
+- [ ] Task Tracker 상태를 **완료**로 변경

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,162 @@
+# CI/CD Workflow 설정 가이드
+
+## 워크플로우 구조
+
+| 파일 | 트리거 | 역할 |
+|------|--------|------|
+| `ci.yml` | dev/main PR | 빌드 + 테스트 + 커버리지 리포트 |
+| `cd.yml` | main 브랜치 push, 수동 실행 | 테스트 → Docker 빌드 → ECR push → ECS 배포 |
+
+## 브랜치 전략
+
+```
+feature/** ──PR──▶ dev ──PR──▶ main
+                                  │
+                                  ▼
+                           production 배포 (CD 자동 실행)
+```
+
+## GitHub Actions 값 설정
+
+GitHub 저장소 → Settings → Secrets and variables → Actions 에서 등록
+
+### Secrets (민감 정보) — Actions secrets 탭
+
+| 이름 | 설명 |
+|------|------|
+| `AWS_ACCESS_KEY_ID` | CD용 IAM 유저 액세스 키 |
+| `AWS_SECRET_ACCESS_KEY` | CD용 IAM 유저 시크릿 키 |
+
+### Variables (비민감 설정값) — Actions variables 탭
+
+| 이름 | 값 | 설명 |
+|------|-----|------|
+| `AWS_REGION` | `ap-northeast-2` | AWS 리전 |
+| `ECR_REPOSITORY` | `deokhugam` | ECR 리포지토리 이름 |
+| `ECS_TASK_DEFINITION` | `task-definition.json` | 리포 루트 기준 파일 경로 |
+| `ECS_SERVICE` | `deokhugam-service` | ECS 서비스 이름 |
+| `ECS_CLUSTER` | `deokhugam-cluster` | ECS 클러스터 이름 |
+
+> `ECS_TASK_DEFINITION`은 Family 이름이 아니라 **파일 경로 문자열**입니다.
+
+---
+
+## IAM 권한 설정
+
+이 프로젝트에는 **IAM 주체가 2개** 존재합니다.  
+역할이 다르기 때문에 정책을 반드시 분리해야 합니다.
+
+### 주체 1: CD용 IAM 유저 (GitHub Actions 배포 주체)
+
+`AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY`로 인증되는 주체입니다.  
+**ECR push와 ECS 배포 호출 권한만 필요합니다.**
+
+#### ❌ 이 유저에서 제거해야 할 정책
+
+| 정책명 | 제거 이유 |
+|--------|-----------|
+| `AmazonECSTaskExecutionRo...` | 태스크 실행 역할용 정책이며, IAM 유저가 아닌 `ecsTaskExecutionRole`에 부여해야 함 |
+| `SecretsManagerAccess` | Secrets Manager 조회는 컨테이너 런타임에 `ecsTaskExecutionRole`이 수행. CD 유저는 불필요 |
+| `AllowReadDiscodeitEnvFromS3` | `task-definition.json`에서 `environmentFiles`를 사용하지 않으므로 불필요 |
+
+#### ✅ 이 유저에 부여할 정책 (인라인 정책으로 추가)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECRLogin",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ECRPush",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Resource": "arn:aws:ecr:ap-northeast-2:297904677990:repository/deokhugam"
+    },
+    {
+      "Sid": "ECSDeployRead",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTaskDefinition",
+        "ecs:DescribeServices"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ECSDeployWrite",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:RegisterTaskDefinition",
+        "ecs:UpdateService"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassExecutionRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::297904677990:role/ecsTaskExecutionRole"
+    }
+  ]
+}
+```
+
+---
+
+### 주체 2: ecsTaskExecutionRole (컨테이너 런타임 주체)
+
+`task-definition.json`의 `executionRoleArn`에 지정된 역할입니다.  
+**컨테이너 시작 시 Secrets Manager에서 시크릿을 조회하는 역할입니다.**
+
+#### ✅ 이 Role에 부여할 정책 (인라인 정책으로 추가)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SecretsManagerRead",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:ap-northeast-2:297904677990:log-group:/ecs/deokhugam-task:*"
+    }
+  ]
+}
+```
+
+> `AmazonECSTaskExecutionRolePolicy` (AWS 관리형) + 위 인라인 정책을 함께 사용하면 됩니다.
+
+---
+
+## 런타임 시크릿 관리
+
+민감값은 GitHub에 저장하지 않고, AWS Secrets Manager로 관리합니다.
+
+| 시크릿 키 | 저장 위치 | 참조 방식 |
+|-----------|-----------|-----------|
+| `JWT_SECRET` | Secrets Manager `deokhugam/prod` | `task-definition.json` `secrets.valueFrom` |
+| `DB_PASSWORD` | Secrets Manager `deokhugam/prod` | `task-definition.json` `secrets.valueFrom` |
+| `NAVER_CLIENT_SECRET` | Secrets Manager `deokhugam/prod` | `task-definition.json` `secrets.valueFrom` |
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -83,7 +83,7 @@ GitHub 저장소 → Settings → Secrets and variables → Actions 에서 등�
         "ecr:UploadLayerPart",
         "ecr:CompleteLayerUpload"
       ],
-      "Resource": "arn:aws:ecr:ap-northeast-2:297904677990:repository/deokhugam"
+      "Resource": "arn:aws:ecr:ap-northeast-2:{aws Id}:repository/deokhugam"
     },
     {
       "Sid": "ECSDeployRead",
@@ -107,7 +107,7 @@ GitHub 저장소 → Settings → Secrets and variables → Actions 에서 등�
       "Sid": "PassExecutionRole",
       "Effect": "Allow",
       "Action": "iam:PassRole",
-      "Resource": "arn:aws:iam::297904677990:role/ecsTaskExecutionRole"
+      "Resource": "arn:aws:iam::{aws Id}:role/ecsTaskExecutionRole"
     }
   ]
 }
@@ -130,7 +130,7 @@ GitHub 저장소 → Settings → Secrets and variables → Actions 에서 등�
       "Sid": "SecretsManagerRead",
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
-      "Resource": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod*"
+      "Resource": "arn:aws:secretsmanager:ap-northeast-2:{aws Id}:secret:deokhugam/prod*"
     },
     {
       "Sid": "CloudWatchLogs",
@@ -140,7 +140,7 @@ GitHub 저장소 → Settings → Secrets and variables → Actions 에서 등�
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],
-      "Resource": "arn:aws:logs:ap-northeast-2:297904677990:log-group:/ecs/deokhugam-task:*"
+      "Resource": "arn:aws:logs:ap-northeast-2:{aws Id}:log-group:/ecs/deokhugam-task:*"
     }
   ]
 }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,56 @@
+name: CD
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: AWS 자격증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: ECR 로그인
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Docker 이미지 빌드 및 ECR push
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            deokhugam/
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: ECS Task Definition 업데이트
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ vars.ECS_TASK_DEFINITION }}
+          container-name: deokhugam-server
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: ECS 배포
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ vars.ECS_SERVICE }}
+          cluster: ${{ vars.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,11 +3,55 @@ name: CD
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: cd-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./deokhugam
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 빌드 및 테스트 실행
+        run: ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification
+        env:
+          SPRING_PROFILES_ACTIVE: test
+
   deploy:
     name: Deploy to ECS
     runs-on: ubuntu-latest
+    needs: build-and-test
 
     steps:
       - name: 코드 체크아웃
@@ -43,7 +87,7 @@ jobs:
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
-          task-definition: ${{ vars.ECS_TASK_DEFINITION }}
+          task-definition: ${{ vars.ECS_TASK_DEFINITION || 'task-definition.json' }}
           container-name: deokhugam-server
           image: ${{ steps.build-image.outputs.image }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,6 +83,11 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      - name: Task Definition ARN 치환
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          sed -i "s/\${AWS_ACCOUNT_ID}/$ACCOUNT_ID/g" task-definition.json
+
       - name: ECS Task Definition 업데이트
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ dev, main ]
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./deokhugam
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 빌드 및 테스트 실행
+        run: ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification
+        env:
+          SPRING_PROFILES_ACTIVE: test
+
+      - name: 테스트 결과 업로드
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: deokhugam/build/reports/tests/test/
+
+      - name: 커버리지 리포트 업로드
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: deokhugam/build/reports/jacoco/test/html/
+
+      - name: Codecov 업로드
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: deokhugam/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,10 @@ nohup.out
 *.bak
 
 ### Docker local override ###
-docker-compose.override.yml
+
+### ECS task definition (local/operational) ###
+# Keep tracked: task-definition.json (used by GitHub Actions CD)
+task-definition-register.json
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# 덕후감 서버 (Deokhugam Server)
+
+[![CI](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/actions/workflows/ci.yml/badge.svg)](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/sprint-sb09-part03-team02/sb09-deokhugam-team02/graph/badge.svg?token=ZHKEENIICM)](https://codecov.io/gh/sprint-sb09-part03-team02/sb09-deokhugam-team02)
+## 🛠 기술 스택
+
+- **Java 17** / **Spring Boot 3.5.**
+- **PostgreSQL** / **JPA** / **QueryDSL 5.1.0**
+- **MapStruct 1.6.2** / **JWT (JJWT 0.12.6)**
+- **AWS S3 (SDK v2)**
+
+## 🚀 실행 방법
+
+```bash
+cd deokhugam
+./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+## 🧪 테스트 및 커버리지
+
+```bash
+cd deokhugam
+./gradlew clean test jacocoTestReport jacocoTestCoverageVerification
+```
+
+- 커버리지 리포트: `deokhugam/build/reports/jacoco/test/html/index.html`
+- 최소 커버리지 기준: **80%**
+

--- a/deokhugam/build.gradle
+++ b/deokhugam/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
 	// DB
 	runtimeOnly 'org.postgresql:postgresql'
 
@@ -57,16 +58,6 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-
-	// MapStruct
-	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
-	implementation 'org.mapstruct:mapstruct:1.6.2'
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.2'
-
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/deokhugam/src/main/resources/application-dev.yml
+++ b/deokhugam/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ spring:
   security:
     user:
       name: admin
-      password: admin
+      password:  ${SPRING_SECURITY_USER_PASSWORD:admin}
 
 cloud:
   aws:

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,87 @@
+{
+  "family": "deokhugam-task",
+  "executionRoleArn": "arn:aws:iam::297904677990:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "containerDefinitions": [
+    {
+      "name": "deokhugam-server",
+      "image": "public.ecr.aws/nginx/nginx:latest",
+      "cpu": 0,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "name": "deokhugam-server-8080-tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "environment": [
+        {
+          "name": "DB_USERNAME",
+          "value": "deokhugam"
+        },
+        {
+          "name": "AWS_S3_BUCKET",
+          "value": "deokhugam-storage"
+        },
+        {
+          "name": "DB_URL",
+          "value": "deokhugam-db.cr0uug8my8f7.ap-northeast-2.rds.amazonaws.com"
+        },
+        {
+          "name": "SPRING_PROFILES_ACTIVE",
+          "value": "prod"
+        },
+        {
+          "name": "NAVER_CLIENT_ID",
+          "value": "e1uIDmHhEkMGuBrzSu2V"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "JWT_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod:JWT_SECRET::"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod:DB_PASSWORD::"
+        },
+        {
+          "name": "NAVER_CLIENT_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod:NAVER_CLIENT_SECRET::"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/deokhugam-task",
+          "awslogs-create-group": "true",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "curl -f http://localhost:8080/actuator/health || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}
+

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,6 +1,6 @@
 {
   "family": "deokhugam-task",
-  "executionRoleArn": "arn:aws:iam::297904677990:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskExecutionRole",
   "networkMode": "awsvpc",
   "requiresCompatibilities": [
     "FARGATE"
@@ -42,24 +42,24 @@
         {
           "name": "SPRING_PROFILES_ACTIVE",
           "value": "prod"
-        },
-        {
-          "name": "NAVER_CLIENT_ID",
-          "value": "e1uIDmHhEkMGuBrzSu2V"
         }
       ],
       "secrets": [
         {
           "name": "JWT_SECRET",
-          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod:JWT_SECRET::"
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:JWT_SECRET::"
         },
         {
           "name": "DB_PASSWORD",
-          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod:DB_PASSWORD::"
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:DB_PASSWORD::"
+        },
+        {
+          "name": "NAVER_CLIENT_ID",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:NAVER_CLIENT_ID::"
         },
         {
           "name": "NAVER_CLIENT_SECRET",
-          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:297904677990:secret:deokhugam/prod:NAVER_CLIENT_SECRET::"
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:NAVER_CLIENT_SECRET::"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/CI-CD-GitHub-Actions-3506e443c2888135b19bc22bde593d87?source=copy_link

---

## 🛠️ 작업 내용

### AWS 인프라 구성 완료

**IAM**
- GitHub Actions 전용 IAM 유저 생성 (`deokhugam`)
- 정책 구성: ECR, ECS, S3, Secrets Manager 접근 권한
- `ecsTaskExecutionRole` 정책 정비 (Secrets Manager 접근 추가)
- `deokhugam-task-role` 신규 생성 (S3 이미지 업로드 전용)

**Secrets Manager**
- `deokhugam/prod` Secret 생성
- 민감정보 등록: `JWT_SECRET`, `DB_PASSWORD`, `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`

**S3**
- `deokhugam-storage` 버킷 생성 (도서 썸네일, 사용자 프로필 이미지 저장)

**ECR**
- `deokhugam-server` 레포지토리 생성 (Docker 이미지 저장소)

**RDS**
- PostgreSQL 16 인스턴스 생성 (`deokhugam-db`)
- 보안 그룹 인바운드 5432 포트 오픈

**ECS**
- Fargate 클러스터 생성 (`deokhugam-cluster`)
- Task Definition 생성 (`deokhugam-task`)
  - 민감정보 Secrets Manager ARN 참조 방식으로 관리
  - 환경변수 분리 (평문 / Secrets Manager 참조)
- Service 생성 (`deokhugam-service`) → Running 확인

**GitHub Secrets 등록**
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
- `S3_BUCKET_NAME`, `ECR_REGISTRY`, `ECR_REPOSITORY`
- `ECS_CLUSTER`, `ECS_SERVICE`, `ECS_TASK_DEFINITION`
- `JWT_SECRET`, `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`
- `DB_URL`, `DB_USERNAME`, `DB_PASSWORD`

### CI/CD 워크플로우 작성

**CI (`ci.yml`)**
- PR 생성 시 자동 실행 (대상 브랜치: `dev`, `main`)
- JDK 17 빌드 + 테스트 실행
- JaCoCo 커버리지 80% 미달 시 CI 실패 처리
- Codecov 연동 (커버리지 배지)

**CD (`cd.yml`)**
- `main` 브랜치 머지 시 자동 실행
- Docker 이미지 빌드 → ECR push
- ECS Task Definition 자동 업데이트
- ECS Service Rolling Update 배포

### Dockerfile 수정
- 멀티 스테이지 빌드 유지 (builder / runner)
- non-root 사용자 보안 설정 유지

### application.yml 환경별 분리
| 파일 | 용도 |
|---|---|
| `application.yml` | 공통 설정 |
| `application-dev.yml` | ECS 배포용 (환경변수 참조) |
| `application-test.yml` | 테스트용 (H2 인메모리) |
| `application-local.yml` | 로컬 개발용 (`.gitignore` 제외) |

---

## 🧪 테스트
- 해당 없음 (인프라 설정)
- ECS 서비스 Running 상태 확인 완료
- AWS 리소스 정상 등록 확인 완료

---

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

---

## ⚠️ 참고 사항
- `application-local.yml`은 팀원 각자 로컬에서 직접 생성 필요 (별도 공유 예정)
- ECS Health Check는 실제 Spring Boot 이미지 배포 후 재활성화 예정
- CI/CD 워크플로우는 첫 실행 후 Branch Protection Rules에 status check 추가 필요