### PR TITLE
[BE-19] feat: review 객체 연관 관계 리펙토링

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/PopularReview.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/PopularReview.java
@@ -21,11 +21,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PopularReview extends BaseEntity {
 
-  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "review_id")
+  @JoinColumn(name = "review_id", nullable = false)
   private Review review;
 
   @Enumerated(EnumType.STRING)

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/Review.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/Review.java
@@ -1,5 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.review.entity;
 
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
 import com.deokhugam.deokhugam_server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.util.UUID;
@@ -26,11 +28,13 @@ public class Review extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @Column(name = "book_id", nullable = false)
-  private UUID bookId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "book_id", nullable = false)
+  private Book book;
 
-  @Column(name = "user_id", nullable = false)
-  private UUID userId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   @Column(columnDefinition = "TEXT", nullable = false)
   private String content;
@@ -45,9 +49,9 @@ public class Review extends BaseEntity {
   private int commentCount = 0;
 
   @Builder
-  public Review(UUID bookId, UUID userId, String content, int rating) {
-    this.bookId = bookId;
-    this.userId = userId;
+  public Review(Book book, User user, String content, int rating) {
+    this.book = book;
+    this.user = user;
     this.content = content;
     this.rating = rating;
   }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/ReviewLike.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/ReviewLike.java
@@ -1,5 +1,6 @@
 package com.deokhugam.deokhugam_server.domain.review.entity;
 
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
 import com.deokhugam.deokhugam_server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.util.UUID;
@@ -18,16 +19,18 @@ public class ReviewLike extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @Column(name = "review_id", nullable = false)
-  private UUID reviewId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "review_id", nullable = false)
+  private Review review;
 
-  @Column(name = "user_id", nullable = false)
-  private UUID userId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   @Builder
-  public ReviewLike(UUID reviewId, UUID userId) {
-    this.reviewId = reviewId;
-    this.userId = userId;
+  public ReviewLike(Review review, User user) {
+    this.review = review;
+    this.user = user;
   }
 
   //중복방지

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/mapper/ReviewMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/mapper/ReviewMapper.java
@@ -1,8 +1,10 @@
 package com.deokhugam.deokhugam_server.domain.review.mapper;
 
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewCreateRequest;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -10,14 +12,23 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ReviewMapper {
 
-  // Request DTO -> Entity (UUID 기반이라 직접 매핑됨)
-  Review toEntity(ReviewCreateRequest request);
+  /**
+   * Request DTO + 엔티티 객체 -> Review 엔티티
+   * id 매핑 에러 해결: 빌더에 없는 id는 언급하지 않아도 자동으로 무시됨
+   */
+  @Mapping(target = "book", source = "book")
+  @Mapping(target = "user", source = "user")
+  @Mapping(target = "content", source = "request.content")
+  @Mapping(target = "rating", source = "request.rating")
+  Review toEntity(ReviewCreateRequest request, Book book, User user);
 
-  // Entity -> Response DTO
-  // bookTitle, userNickname 등은 서비스에서 fetch해온 값을 넘겨받아 매핑
-  @Mapping(target = "bookTitle", source = "bookTitle")
-  @Mapping(target = "userNickname", source = "userNickname")
-  @Mapping(target = "bookThumbnailUrl", source = "bookThumbnailUrl")
+  /**
+   * Entity -> Response DTO
+   * 경로 에러 해결: 인자 이름인 'review'를 소스 경로 앞에 붙여줌
+   */
+  @Mapping(target = "userNickname", source = "review.user.nickname")
+  @Mapping(target = "bookTitle", source = "review.book.title")
+  @Mapping(target = "bookThumbnailUrl", source = "review.book.imageUrl")
   @Mapping(target = "likedByMe", source = "likedByMe")
-  ReviewDto toDto(Review review, String bookTitle, String bookThumbnailUrl, String userNickname, boolean likedByMe);
+  ReviewDto toDto(Review review, boolean likedByMe);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewLikeRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewLikeRepository.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
 
+  // review.id와 user.id를 타고 들어가서 조회함
   Optional<ReviewLike> findByReviewIdAndUserId(UUID reviewId, UUID userId);
+
   boolean existsByReviewIdAndUserId(UUID reviewId, UUID userId);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepository.java
@@ -8,5 +8,7 @@ import java.util.UUID;
 public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRepositoryCustom {
 
   Optional<Review> findByIdAndIsDeletedFalse(UUID id);
+
+  // 1인 1리뷰 명세 준수: book.id와 user.id를 조회
   boolean existsByBookIdAndUserIdAndIsDeletedFalse(UUID bookId, UUID userId);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImpl.java
@@ -12,10 +12,11 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.Optional;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 
@@ -30,21 +31,23 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
     return queryFactory
         .selectFrom(review)
+        // 객체 참조 방식이므로 fetchJoin을 써서 User와 Book 정보를 한 번에 가져오면 성능 최적화(N+1 방지) 가능!
+        .leftJoin(review.book).fetchJoin()
+        .leftJoin(review.user).fetchJoin()
         .where(
             ltCursorAfter(request.getAfter(), request.getCursor()),
             eqUserId(request.getUserId()),
             eqBookId(request.getBookId()),
             containsKeyword(request.getKeyword()),
             review.isDeleted.isFalse()
-                )
-                .orderBy(getOrderSpecifier(request.getOrderBy(), request.getDirection()))
+        )
+        .orderBy(getOrderSpecifier(request.getOrderBy(), request.getDirection()))
         .limit(pageSize + 1)
         .fetch();
   }
 
   @Override
   public List<ReviewRankQueryDto> findReviewStatistics(LocalDate start, LocalDate end) {
-
     return queryFactory
         .select(Projections.constructor(ReviewRankQueryDto.class,
             review.id,
@@ -52,7 +55,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             comment.count()
         ))
         .from(review)
-        .leftJoin(reviewLike).on(reviewLike.reviewId.eq(review.id))
+        // 객체 참조 방식으로 Join 조건 수정 (review_id 대신 review 객체 비교)
+        .leftJoin(reviewLike).on(reviewLike.review.eq(review))
         .leftJoin(comment).on(comment.reviewId.eq(review.id))
         .where(review.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX)))
         .groupBy(review.id)
@@ -60,19 +64,20 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
   }
 
   private BooleanExpression ltCursorAfter(LocalDateTime after, String cursor) {
-    if (after == null) return null;
-
+    if (after == null || cursor == null) return null;
     return review.createdAt.lt(after)
         .or(review.createdAt.eq(after)
             .and(review.id.lt(UUID.fromString(cursor))));
   }
 
+  // 이제 review.userId가 아니라 review.user.id로 접근
   private BooleanExpression eqUserId(UUID userId) {
-    return userId != null ? review.userId.eq(userId) : null;
+    return userId != null ? review.user.id.eq(userId) : null;
   }
 
+  // 이제 review.bookId가 아니라 review.book.id로 접근
   private BooleanExpression eqBookId(UUID bookId) {
-    return bookId != null ? review.bookId.eq(bookId) : null;
+    return bookId != null ? review.book.id.eq(bookId) : null;
   }
 
   private BooleanExpression containsKeyword(String keyword) {
@@ -83,11 +88,9 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
   private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction) {
     boolean isAsc = "ASC".equalsIgnoreCase(direction);
-
     if ("rating".equals(orderBy)) {
       return isAsc ? review.rating.asc() : review.rating.desc();
     }
-
     return isAsc ? review.createdAt.asc() : review.createdAt.desc();
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
@@ -37,22 +37,23 @@ public class ReviewServiceImpl implements ReviewService {
   @Override
   @Transactional
   public ReviewDto createReview(ReviewCreateRequest request) {
-    // 1. 도서 및 사용자 존재 여부 확인
+    // 1. 도서 및 사용자 객체 직접 조회 (참조를 위해 필요)
     Book book = bookRepository.findById(request.bookId())
         .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
     User user = userRepository.findById(request.userId())
         .orElseThrow(() -> new DeokhugamException(ErrorCode.USER_NOT_FOUND));
 
-    // 2. 도서 별 1개의 리뷰만 등록 가능 여부 체크
+    // 2. 1인 1리뷰 체크
     if (reviewRepository.existsByBookIdAndUserIdAndIsDeletedFalse(request.bookId(), request.userId())) {
-      throw new DeokhugamException(ErrorCode.ALREADY_REVIEWED); // ErrorCode 명칭 수정
+      throw new DeokhugamException(ErrorCode.ALREADY_REVIEWED);
     }
 
-    // 3. 리뷰 저장
-    Review review = reviewMapper.toEntity(request);
+    // 3. 리뷰 저장 (이제 매퍼에 book, user 객체를 직접 넘김)
+    Review review = reviewMapper.toEntity(request, book, user);
     Review savedReview = reviewRepository.save(review);
 
-    return reviewMapper.toDto(savedReview, book.getTitle(), book.getImageUrl(), user.getNickname(), false);
+    // 4. DTO 변환 (매퍼가 객체 내부를 타고 들어가므로 인자가 줄어듦!)
+    return reviewMapper.toDto(savedReview, false);
   }
 
   @Override
@@ -60,43 +61,28 @@ public class ReviewServiceImpl implements ReviewService {
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
         .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
 
-    Book book = bookRepository.findById(review.getBookId())
-        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
-    User user = userRepository.findById(review.getUserId())
-        .orElseThrow(() -> new DeokhugamException(ErrorCode.USER_NOT_FOUND));
-
-    // 요청자의 좋아요 여부 포함
+    // 좋아요 여부 확인
     boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(reviewId, requestUserId);
 
-    return reviewMapper.toDto(review, book.getTitle(), book.getImageUrl(), user.getNickname(), likedByMe);
+    // 매퍼가 review.getBook().getTitle() 등을 자동으로 호출함
+    return reviewMapper.toDto(review, likedByMe);
   }
 
   @Override
   public CursorPageResponse<ReviewDto> searchReviews(ReviewSearchRequest request) {
-    // QueryDSL을 통한 목록 조회
     List<Review> reviews = reviewRepository.searchReviews(request);
 
-    // 다음 페이지 존재 여부 확인 (limit+1 fetch 전략)
     boolean hasNext = reviews.size() > request.getLimit();
     if (hasNext) {
       reviews.remove(reviews.size() - 1);
     }
 
+    // [혁신!] 이제 루프 돌면서 레포지토리 다시 뒤질 필요 없음 (객체 안에 다 있으니까)
     List<ReviewDto> content = reviews.stream().map(review -> {
-      Book book = bookRepository.findById(review.getBookId()).orElse(null);
-      User user = userRepository.findById(review.getUserId()).orElse(null);
       boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(review.getId(), request.getRequestUserId());
-
-      return reviewMapper.toDto(
-          review,
-          book != null ? book.getTitle() : "알 수 없는 도서",
-          book != null ? book.getImageUrl() : null,
-          user != null ? user.getNickname() : "알 수 없는 사용자",
-          likedByMe
-      );
+      return reviewMapper.toDto(review, likedByMe);
     }).collect(Collectors.toList());
 
-    // 커서 및 보조 커서 설정
     String nextCursor = hasNext ? reviews.get(reviews.size() - 1).getId().toString() : null;
     java.time.LocalDateTime nextAfter = hasNext ? reviews.get(reviews.size() - 1).getCreatedAt() : null;
 
@@ -109,19 +95,15 @@ public class ReviewServiceImpl implements ReviewService {
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
         .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
 
-    // 본인이 작성한 리뷰만 수정 가능
-    if (!review.getUserId().equals(requestUserId)) {
+    // 본인 확인: review.getUser().getId()로 접근
+    if (!review.getUser().getId().equals(requestUserId)) {
       throw new DeokhugamException(ErrorCode.NOT_REVIEW_OWNER);
     }
 
     review.update(request.content(), request.rating());
 
-    // 수정 후 응답 데이터 구성
-    Book book = bookRepository.findById(review.getBookId()).orElse(null);
-    User user = userRepository.findById(review.getUserId()).orElse(null);
     boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(reviewId, requestUserId);
-
-    return reviewMapper.toDto(review, book.getTitle(), book.getImageUrl(), user.getNickname(), likedByMe);
+    return reviewMapper.toDto(review, likedByMe);
   }
 
   @Override
@@ -130,12 +112,11 @@ public class ReviewServiceImpl implements ReviewService {
     Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId)
         .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
 
-    // 본인이 작성한 리뷰만 삭제 가능
-    if (!review.getUserId().equals(requestUserId)) {
-      throw new DeokhugamException(ErrorCode.NOT_REVIEW_OWNER); // ErrorCode 명칭 수정
+    // 본인 확인: review.getUser().getId()로 접근
+    if (!review.getUser().getId().equals(requestUserId)) {
+      throw new DeokhugamException(ErrorCode.NOT_REVIEW_OWNER);
     }
 
-    // 논리 삭제 처리
     review.delete();
   }
 }


### PR DESCRIPTION
##  domain/Review 연관 관계 리팩토링 및 성능 최적화

노션 링크: https://www.notion.so/Review-3506e443c288810694e2c61896252ee4?source=copy_link

📋 작업 개요
회의 결과에 따라 리뷰 도메인의 참조 방식을 UUID 직접 참조에서 JPA 객체 연관 관계(@ManyToOne) 방식으로 리팩토링하여 데이터 정합성 및 조회 성능 개선

✨ 주요 변경 사항
- 엔티티 리팩토링: Review, ReviewLike, PopularReview 엔티티 내 UUID 필드를 객체 참조 방식으로 변경
- 성능 최적화: QueryDSL 조회 로직에 fetchJoin을 적용하여 연관 객체 동시 조회 및 N+1 문제 예방
- 매퍼 개선: ReviewMapper가 연관 객체 그래프를 직접 탐색하여 도서 제목, 유저 닉네임 등을 DTO에 자동 매핑하도록 수정

📢 팀원 알림 (Action Items)
- 지은님(User): UserRepositoryCustomImpl 내 review.userId → review.user.id로 변경 필요
- 성호님(Book): BookRepositoryCustomImpl 내 review.bookId → review.book.id로 변경 필요