### PR TITLE
[BE-28]feat(book): implement book controller CRUD API

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
@@ -1,0 +1,50 @@
+package com.deokhugam.deokhugam_server.domain.book.controller;
+
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookCreateRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
+import com.deokhugam.deokhugam_server.domain.book.service.BookService;
+import com.deokhugam.deokhugam_server.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+public class BookController {
+
+    private final BookService bookService;
+
+    @PostMapping
+    public ApiResponse<BookDto> createBook(@Valid @RequestBody BookCreateRequest request) {
+        return ApiResponse.success(bookService.createBook(request), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{bookId}")
+    public ApiResponse<BookDto> getBook(@PathVariable UUID bookId) {
+        return ApiResponse.success(bookService.getBook(bookId));
+    }
+
+    @PatchMapping("/{bookId}")
+    public ApiResponse<BookDto> updateBook(
+            @PathVariable UUID bookId,
+            @Valid @RequestBody BookUpdateRequest request
+    ) {
+        return ApiResponse.success(bookService.updateBook(bookId, request));
+    }
+
+    @DeleteMapping("/{bookId}")
+    public ApiResponse<Void> deleteBook(@PathVariable UUID bookId) {
+        bookService.deleteBook(bookId);
+        return ApiResponse.success(null, HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping("/{bookId}/hard")
+    public ApiResponse<Void> hardDeleteBook(@PathVariable UUID bookId) {
+        bookService.hardDeleteBook(bookId);
+        return ApiResponse.success(null, HttpStatus.NO_CONTENT);
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/dto/response/BookRankQueryDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/dto/response/BookRankQueryDto.java
@@ -3,13 +3,14 @@ package com.deokhugam.deokhugam_server.domain.book.dto.response;
 import java.util.UUID;
 
 public record BookRankQueryDto(
-
-    UUID bookId,
-    Long reviewCount,
-    Double avgRating
-
+        UUID bookId,
+        Long reviewCount,
+        Double avgRating
 ) {
   public Double calculateScore() {
-    return (reviewCount * 0.4) + (avgRating * 0.6);
+    long safeReviewCount = reviewCount == null ? 0L : reviewCount;
+    double safeAvgRating = avgRating == null ? 0.0 : avgRating;
+
+    return (safeReviewCount * 0.4) + (safeAvgRating * 0.6);
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/PopularBook.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/PopularBook.java
@@ -11,26 +11,24 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 @Entity
+@Table(name = "popular_books")
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PopularBook extends BaseEntity {
 
   @Id
+  @GeneratedValue
   @UuidGenerator
   @Column(name = "id", nullable = false, updatable = false)
-
   private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -50,28 +48,31 @@ public class PopularBook extends BaseEntity {
   @Column(name = "calculated_date", nullable = false)
   private LocalDate calculatedDate;
 
-
+  @Column(name = "review_count", nullable = false)
   private Long reviewCount;
 
+  @Column(name = "rating", nullable = false)
   private Double rating;
-
-  public void assignRankOrder(int rank) {
-    this.rankOrder = rank;
-  }
-}
 
   public PopularBook(
           Book book,
           Period periodType,
           Double score,
           Integer rankOrder,
-          LocalDate calculatedDate
+          LocalDate calculatedDate,
+          Long reviewCount,
+          Double rating
   ) {
     this.book = book;
     this.periodType = periodType;
     this.score = score;
     this.rankOrder = rankOrder;
     this.calculatedDate = calculatedDate;
+    this.reviewCount = reviewCount;
+    this.rating = rating;
+  }
+
+  public void assignRankOrder(int rank) {
+    this.rankOrder = rank;
   }
 }
-

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/mapper/BookMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/mapper/BookMapper.java
@@ -1,10 +1,8 @@
 package com.deokhugam.deokhugam_server.domain.book.mapper;
 
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
-import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import org.springframework.stereotype.Component;
-import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
 
 @Component
 public class BookMapper {
@@ -25,20 +23,4 @@ public class BookMapper {
                 book.getUpdatedAt()
         );
     }
-
-  public static PopularBookDto toPopularDto(PopularBook entity) {
-    return new PopularBookDto(
-        entity.getId(),
-        entity.getBook().getId(),
-        entity.getBook().getTitle(),
-        entity.getBook().getAuthor(),
-        entity.getBook().getImageUrl(),
-        entity.getPeriodType(),
-        entity.getRankOrder(),
-        entity.getScore(),
-        entity.getReviewCount().intValue(),
-        entity.getRating(),
-        entity.getCreatedAt()
-    );
-  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/mapper/PopularBookMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/mapper/PopularBookMapper.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class PopularBookMapper {
 
-    public PopularBookDto toDto(PopularBook popularBook, int reviewCount, double rating) {
+    public PopularBookDto toDto(PopularBook popularBook) {
         return new PopularBookDto(
                 popularBook.getId(),
                 popularBook.getBook().getId(),
@@ -17,8 +17,8 @@ public class PopularBookMapper {
                 popularBook.getPeriodType(),
                 popularBook.getRankOrder(),
                 popularBook.getScore(),
-                reviewCount,
-                rating,
+                popularBook.getReviewCount().intValue(),
+                popularBook.getRating(),
                 popularBook.getCreatedAt()
         );
     }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/PopularBookRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/PopularBookRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> {
 
-  List<PopularBook> findAllByPeriodTypeAndCalculatedDate(Period periodType, LocalDate calculatedDate);
+  List<PopularBook> findAllByPeriodTypeAndCalculatedDateOrderByRankOrderAsc(
+          Period periodType,
+          LocalDate calculatedDate
+  );
 }
-

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/PopularBookService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/PopularBookService.java
@@ -1,10 +1,9 @@
 package com.deokhugam.deokhugam_server.domain.book.service;
 
-
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
-import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
+import com.deokhugam.deokhugam_server.domain.book.mapper.PopularBookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.book.repository.PopularBookRepository;
 import com.deokhugam.deokhugam_server.global.type.Period;
@@ -22,7 +21,7 @@ public class PopularBookService {
 
   private final BookRepository bookRepository;
   private final PopularBookRepository popularBookRepository;
-
+  private final PopularBookMapper popularBookMapper;
 
   @Transactional
   public void calculateAndSaveRanks(Period periodType) {
@@ -32,34 +31,37 @@ public class PopularBookService {
     List<BookRankQueryDto> statistics = bookRepository.findBookStatisticsForRanking(startDate, endDate);
 
     List<PopularBook> rankings = statistics.stream()
-        .map(stat -> PopularBook.builder()
-            .book(bookRepository.getReferenceById(stat.bookId()))
-            .periodType(periodType)
-            .score(stat.calculateScore())
-            .reviewCount(stat.reviewCount())
-            .rating(stat.avgRating())
-            .calculatedDate(endDate)
-            .build())
-        .sorted(Comparator.comparing(PopularBook::getScore).reversed())
-        .toList();
+            .map(stat -> new PopularBook(
+                    bookRepository.getReferenceById(stat.bookId()),
+                    periodType,
+                    stat.calculateScore(),
+                    0,
+                    endDate,
+                    stat.reviewCount() == null ? 0L : stat.reviewCount(),
+                    stat.avgRating() == null ? 0.0 : stat.avgRating()
+            ))
+            .sorted(Comparator.comparing(PopularBook::getScore).reversed())
+            .toList();
 
     for (int i = 0; i < rankings.size(); i++) {
       rankings.get(i).assignRankOrder(i + 1);
     }
 
     List<PopularBook> existingRankings =
-        popularBookRepository.findAllByPeriodTypeAndCalculatedDate(periodType, endDate);
+            popularBookRepository.findAllByPeriodTypeAndCalculatedDateOrderByRankOrderAsc(periodType, endDate);
+
     if (!existingRankings.isEmpty()) {
       popularBookRepository.deleteAll(existingRankings);
     }
+
     popularBookRepository.saveAll(rankings);
   }
 
   public List<PopularBookDto> getPopularBooks(Period periodType, LocalDate date) {
-    return popularBookRepository.findAllByPeriodTypeAndCalculatedDate(periodType, date)
-        .stream()
-        .map(BookMapper::toPopularDto)
-        .toList();
+    return popularBookRepository.findAllByPeriodTypeAndCalculatedDateOrderByRankOrderAsc(periodType, date)
+            .stream()
+            .map(popularBookMapper::toDto)
+            .toList();
   }
 
   private LocalDate getStartDate(Period type, LocalDate endDate) {


### PR DESCRIPTION
- 도서 생성 API 구현 (POST /api/books)
- 도서 단건 조회 API 구현 (GET /api/books/{bookId})
- 도서 수정 API 구현 (PATCH /api/books/{bookId})
- 도서 논리 삭제 API 구현 (DELETE /api/books/{bookId})
- 도서 물리 삭제 API 구현 (DELETE /api/books/{bookId}/hard)

- BookCreateRequest, BookUpdateRequest 기반 유효성 검증 적용
- ApiResponse 공통 응답 구조 적용
- BookService와 연동하여 비즈니스 로직 위임

[설계 및 정책]
- ISBN 중복 생성 방지 로직 반영 (Service 레이어)
- ISBN 수정 불가 구조 유지 (UpdateRequest에 ISBN 제외)
- 논리 삭제 기본 정책 적용 (soft delete)
- 물리 삭제는 별도 API로 분리

[비고]
- 목록 조회 API (검색/정렬/커서 페이지네이션)는 별도 브랜치(feature/book-query)에서 구현 예정

## 📋 관련 Issue

Closes #{issue_number}

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion:

## 🛠️ 작업 내용
<!-- 변경 사항을 간략히 설명해주세요 -->



## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경