### PR TITLE
[BE-28]feat: book 컨트롤러 CRUD 및 목록 조회 API 구조 구현

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
@@ -1,33 +1,97 @@
 package com.deokhugam.deokhugam_server.domain.book.controller;
 
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookCreateRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.service.BookService;
+import com.deokhugam.deokhugam_server.global.response.ApiResponse;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("api/books")
+@RequestMapping("/api/books")
 @RequiredArgsConstructor
 public class BookController {
 
   private final BookService bookService;
 
-  @GetMapping("/popular")
-  public ResponseEntity<List<PopularBookDto>> searchPopularBooks(
-      @RequestParam(defaultValue = "DAILY") Period period,
-      @RequestParam(defaultValue = "ASC") String direction,
-      @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) String after,
-      @RequestParam(defaultValue = "50") int limit
+  @PostMapping(consumes = "multipart/form-data")
+  public ApiResponse<BookDto> createBook(
+          @Valid @ModelAttribute BookCreateRequest request,
+          @RequestParam(required = false) MultipartFile thumbnailImage
   ) {
-    List<PopularBookDto> popularBooks = bookService.searchPopularBooks(period, direction, cursor, after,
-        limit);
-    return ResponseEntity.ok(popularBooks);
+    BookDto response = bookService.createBook(request, thumbnailImage);
+    return ApiResponse.success(response, HttpStatus.CREATED);
+  }
+
+  @GetMapping
+  public ApiResponse<CursorPageResponse<BookDto>> getBooks(
+          @Valid @ModelAttribute BookSearchRequest request
+  ) {
+    CursorPageResponse<BookDto> response = bookService.getBooks(request);
+    return ApiResponse.success(response);
+  }
+
+  @GetMapping("/{bookId}")
+  public ApiResponse<BookDto> getBook(@PathVariable UUID bookId) {
+    BookDto response = bookService.getBook(bookId);
+    return ApiResponse.success(response);
+  }
+
+  @PatchMapping(value = "/{bookId}", consumes = "multipart/form-data")
+  public ApiResponse<BookDto> updateBook(
+          @PathVariable UUID bookId,
+          @Valid @ModelAttribute BookUpdateRequest request,
+          @RequestParam(required = false) MultipartFile thumbnailImage
+  ) {
+    BookDto response = bookService.updateBook(bookId, request, thumbnailImage);
+    return ApiResponse.success(response);
+  }
+
+  @DeleteMapping("/{bookId}")
+  public ApiResponse<Void> deleteBook(@PathVariable UUID bookId) {
+    bookService.deleteBook(bookId);
+    return ApiResponse.success(null, HttpStatus.NO_CONTENT);
+  }
+
+  @DeleteMapping("/{bookId}/hard")
+  public ApiResponse<Void> hardDeleteBook(@PathVariable UUID bookId) {
+    bookService.hardDeleteBook(bookId);
+    return ApiResponse.success(null, HttpStatus.NO_CONTENT);
+  }
+
+  @GetMapping("/popular")
+  public ApiResponse<List<PopularBookDto>> searchPopularBooks(
+          @RequestParam(defaultValue = "DAILY") Period period,
+          @RequestParam(defaultValue = "ASC") String direction,
+          @RequestParam(required = false) String cursor,
+          @RequestParam(required = false) String after,
+          @RequestParam(defaultValue = "50") int limit
+  ) {
+    List<PopularBookDto> popularBooks = bookService.searchPopularBooks(
+            period,
+            direction,
+            cursor,
+            after,
+            limit
+    );
+    return ApiResponse.success(popularBooks);
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/dto/response/BookSearchQueryDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/dto/response/BookSearchQueryDto.java
@@ -1,0 +1,21 @@
+package com.deokhugam.deokhugam_server.domain.book.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record BookSearchQueryDto(
+    UUID id,
+    String title,
+    String author,
+    String description,
+    String publisher,
+    LocalDate publishedDate,
+    String isbn,
+    String thumbnailUrl,
+    long reviewCount,
+    double rating,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/mapper/BookMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/mapper/BookMapper.java
@@ -1,48 +1,68 @@
 package com.deokhugam.deokhugam_server.domain.book.mapper;
 
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.BookSearchQueryDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
-import org.springframework.stereotype.Component;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
+import org.springframework.stereotype.Component;
 
 @Component
 public class BookMapper {
 
   public BookDto toDto(Book book, int reviewCount, double rating) {
     return new BookDto(
-        book.getId(),
-        book.getTitle(),
-        book.getAuthor(),
-        book.getDescription(),
-        book.getPublisher(),
-        book.getPublishedDate(),
-        book.getIsbn(),
-        book.getThumbnailUrl(),
-        reviewCount,
-        rating,
-        book.getCreatedAt(),
-        book.getUpdatedAt()
+            book.getId(),
+            book.getTitle(),
+            book.getAuthor(),
+            book.getDescription(),
+            book.getPublisher(),
+            book.getPublishedDate(),
+            book.getIsbn(),
+            book.getThumbnailUrl(),
+            reviewCount,
+            rating,
+            book.getCreatedAt(),
+            book.getUpdatedAt()
+    );
+  }
+
+  public BookDto toDto(BookSearchQueryDto queryDto) {
+    return new BookDto(
+            queryDto.id(),
+            queryDto.title(),
+            queryDto.author(),
+            queryDto.description(),
+            queryDto.publisher(),
+            queryDto.publishedDate(),
+            queryDto.isbn(),
+            queryDto.thumbnailUrl(),
+            (int) queryDto.reviewCount(),
+            queryDto.rating(),
+            queryDto.createdAt(),
+            queryDto.updatedAt()
     );
   }
 
   public PopularBookDto toPopularDto(PopularBook popularBook) {
-    if (popularBook == null)
+    if (popularBook == null) {
       return null;
+    }
+
     Book book = popularBook.getBook();
 
     return new PopularBookDto(
-        popularBook.getId(),
-        book.getId(),
-        book.getTitle(),
-        book.getAuthor(),
-        book.getThumbnailUrl(),
-        popularBook.getPeriodType(),
-        popularBook.getRankOrder(),
-        popularBook.getScore(),
-        popularBook.getReviewCount().intValue(),
-        popularBook.getRating(),
-        popularBook.getCreatedAt()
+            popularBook.getId(),
+            book.getId(),
+            book.getTitle(),
+            book.getAuthor(),
+            book.getThumbnailUrl(),
+            popularBook.getPeriodType(),
+            popularBook.getRankOrder(),
+            popularBook.getScore(),
+            popularBook.getReviewCount().intValue(),
+            popularBook.getRating(),
+            popularBook.getCreatedAt()
     );
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustom.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustom.java
@@ -2,13 +2,13 @@ package com.deokhugam.deokhugam_server.domain.book.repository;
 
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookRankQueryDto;
-import com.deokhugam.deokhugam_server.domain.book.entity.Book;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.BookSearchQueryDto;
 import java.time.LocalDate;
 import java.util.List;
 
 public interface BookRepositoryCustom {
 
-    List<Book> searchBooks(BookSearchRequest request);
+    List<BookSearchQueryDto> searchBooks(BookSearchRequest request);
 
     long countBooks(BookSearchRequest request);
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
@@ -1,16 +1,25 @@
 package com.deokhugam.deokhugam_server.domain.book.repository;
 
+import static com.deokhugam.deokhugam_server.domain.book.entity.QBook.book;
 import static com.deokhugam.deokhugam_server.domain.review.entity.QReview.review;
 
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookRankQueryDto;
-import com.deokhugam.deokhugam_server.domain.book.entity.Book;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.BookSearchQueryDto;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateExpression;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 public class BookRepositoryCustomImpl implements BookRepositoryCustom {
@@ -18,32 +27,203 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public List<Book> searchBooks(BookSearchRequest request) {
-    throw new UnsupportedOperationException("searchBooks는 아직 구현되지 않았습니다.");
+  public List<BookSearchQueryDto> searchBooks(BookSearchRequest request) {
+    NumberExpression<Long> reviewCountExpression = review.id.countDistinct();
+    NumberExpression<Double> ratingExpression = review.rating.avg().coalesce(0.0);
+
+    return queryFactory
+            .select(Projections.constructor(
+                    BookSearchQueryDto.class,
+                    book.id,
+                    book.title,
+                    book.author,
+                    book.description,
+                    book.publisher,
+                    book.publishedDate,
+                    book.isbn,
+                    book.thumbnailUrl,
+                    reviewCountExpression,
+                    ratingExpression,
+                    book.createdAt,
+                    book.updatedAt
+            ))
+            .from(book)
+            .leftJoin(review).on(
+                    review.book.eq(book),
+                    review.isDeleted.isFalse()
+            )
+            .where(
+                    book.isDeleted.isFalse(),
+                    containsKeyword(request.keyword()),
+                    applyCursorCondition(request, reviewCountExpression, ratingExpression)
+            )
+            .groupBy(
+                    book.id,
+                    book.title,
+                    book.author,
+                    book.description,
+                    book.publisher,
+                    book.publishedDate,
+                    book.isbn,
+                    book.thumbnailUrl,
+                    book.createdAt,
+                    book.updatedAt
+            )
+            .orderBy(
+                    getPrimaryOrderSpecifier(request.orderBy(), request.direction(), reviewCountExpression, ratingExpression),
+                    getCreatedAtOrderSpecifier(request.direction())
+            )
+            .limit(request.limit() + 1L)
+            .fetch();
   }
 
   @Override
   public long countBooks(BookSearchRequest request) {
-    throw new UnsupportedOperationException("countBooks는 아직 구현되지 않았습니다.");
+    Long count = queryFactory
+            .select(book.count())
+            .from(book)
+            .where(
+                    book.isDeleted.isFalse(),
+                    containsKeyword(request.keyword())
+            )
+            .fetchOne();
+
+    return count == null ? 0L : count;
   }
 
   @Override
   public List<BookRankQueryDto> findBookStatisticsForRanking(LocalDate startDate, LocalDate endDate) {
     return queryFactory
-        .select(Projections.constructor(
-            BookRankQueryDto.class,
-            review.book.id,
-            review.id.countDistinct(),
-            review.rating.avg()
-        ))
-        .from(review)
-        .where(
-            review.createdAt.between(
-                startDate.atStartOfDay(),
-                endDate.atTime(LocalTime.MAX)
+            .select(Projections.constructor(
+                    BookRankQueryDto.class,
+                    review.book.id,
+                    review.id.countDistinct(),
+                    review.rating.avg()
+            ))
+            .from(review)
+            .where(
+                    review.createdAt.between(
+                            startDate.atStartOfDay(),
+                            endDate.atTime(LocalTime.MAX)
+                    )
             )
-        )
-        .groupBy(review.book.id)
-        .fetch();
+            .groupBy(review.book.id)
+            .fetch();
+  }
+
+  private BooleanExpression containsKeyword(String keyword) {
+    if (!StringUtils.hasText(keyword)) {
+      return null;
+    }
+
+    return book.title.containsIgnoreCase(keyword)
+            .or(book.author.containsIgnoreCase(keyword))
+            .or(book.isbn.containsIgnoreCase(keyword));
+  }
+
+  private BooleanExpression applyCursorCondition(
+          BookSearchRequest request,
+          NumberExpression<Long> reviewCountExpression,
+          NumberExpression<Double> ratingExpression
+  ) {
+    if (!StringUtils.hasText(request.cursor()) || request.after() == null) {
+      return null;
+    }
+
+    String orderBy = request.orderBy();
+    String direction = request.direction();
+
+    return switch (orderBy) {
+      case "publishedDate" -> comparePublishedDateCursor(request.cursor(), request.after(), direction);
+      case "rating" -> compareRatingCursor(request.cursor(), request.after(), direction, ratingExpression);
+      case "reviewCount" -> compareReviewCountCursor(request.cursor(), request.after(), direction, reviewCountExpression);
+      case "title" -> compareTitleCursor(request.cursor(), request.after(), direction);
+      default -> compareTitleCursor(request.cursor(), request.after(), direction);
+    };
+  }
+
+  private BooleanExpression compareTitleCursor(String cursor, java.time.LocalDateTime after, String direction) {
+    if (isAsc(direction)) {
+      return book.title.gt(cursor)
+              .or(book.title.eq(cursor).and(book.createdAt.gt(after)));
+    }
+
+    return book.title.lt(cursor)
+            .or(book.title.eq(cursor).and(book.createdAt.lt(after)));
+  }
+
+  private BooleanExpression comparePublishedDateCursor(
+          String cursor,
+          java.time.LocalDateTime after,
+          String direction
+  ) {
+    LocalDate publishedDateCursor = LocalDate.parse(cursor);
+
+    if (isAsc(direction)) {
+      return book.publishedDate.gt(publishedDateCursor)
+              .or(book.publishedDate.eq(publishedDateCursor).and(book.createdAt.gt(after)));
+    }
+
+    return book.publishedDate.lt(publishedDateCursor)
+            .or(book.publishedDate.eq(publishedDateCursor).and(book.createdAt.lt(after)));
+  }
+
+  private BooleanExpression compareRatingCursor(
+          String cursor,
+          java.time.LocalDateTime after,
+          String direction,
+          NumberExpression<Double> ratingExpression
+  ) {
+    double ratingCursor = Double.parseDouble(cursor);
+
+    if (isAsc(direction)) {
+      return ratingExpression.gt(ratingCursor)
+              .or(ratingExpression.eq(ratingCursor).and(book.createdAt.gt(after)));
+    }
+
+    return ratingExpression.lt(ratingCursor)
+            .or(ratingExpression.eq(ratingCursor).and(book.createdAt.lt(after)));
+  }
+
+  private BooleanExpression compareReviewCountCursor(
+          String cursor,
+          java.time.LocalDateTime after,
+          String direction,
+          NumberExpression<Long> reviewCountExpression
+  ) {
+    long reviewCountCursor = Long.parseLong(cursor);
+
+    if (isAsc(direction)) {
+      return reviewCountExpression.gt(reviewCountCursor)
+              .or(reviewCountExpression.eq(reviewCountCursor).and(book.createdAt.gt(after)));
+    }
+
+    return reviewCountExpression.lt(reviewCountCursor)
+            .or(reviewCountExpression.eq(reviewCountCursor).and(book.createdAt.lt(after)));
+  }
+
+  private OrderSpecifier<?> getPrimaryOrderSpecifier(
+          String orderBy,
+          String direction,
+          NumberExpression<Long> reviewCountExpression,
+          NumberExpression<Double> ratingExpression
+  ) {
+    Order order = isAsc(direction) ? Order.ASC : Order.DESC;
+
+    return switch (orderBy) {
+      case "publishedDate" -> new OrderSpecifier<>(order, book.publishedDate);
+      case "rating" -> new OrderSpecifier<>(order, ratingExpression);
+      case "reviewCount" -> new OrderSpecifier<>(order, reviewCountExpression);
+      case "title" -> new OrderSpecifier<>(order, book.title);
+      default -> new OrderSpecifier<>(order, book.title);
+    };
+  }
+
+  private OrderSpecifier<?> getCreatedAtOrderSpecifier(String direction) {
+    return isAsc(direction) ? book.createdAt.asc() : book.createdAt.desc();
+  }
+
+  private boolean isAsc(String direction) {
+    return "ASC".equalsIgnoreCase(direction);
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookService.java
@@ -1,25 +1,35 @@
 package com.deokhugam.deokhugam_server.domain.book.service;
 
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookCreateRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface BookService {
 
-    BookDto createBook(BookCreateRequest request);
+    BookDto createBook(BookCreateRequest request, MultipartFile thumbnailImage);
+
+    CursorPageResponse<BookDto> getBooks(BookSearchRequest request);
 
     BookDto getBook(UUID bookId);
 
-    BookDto updateBook(UUID bookId, BookUpdateRequest request);
+    BookDto updateBook(UUID bookId, BookUpdateRequest request, MultipartFile thumbnailImage);
 
     void deleteBook(UUID bookId);
 
     void hardDeleteBook(UUID bookId);
 
-    List<PopularBookDto> searchPopularBooks(Period period, String direction, String cursor, String after, int limit);
-
+    List<PopularBookDto> searchPopularBooks(
+            Period period,
+            String direction,
+            String cursor,
+            String after,
+            int limit
+    );
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -1,8 +1,10 @@
 package com.deokhugam.deokhugam_server.domain.book.service;
 
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookCreateRequest;
+import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.BookSearchQueryDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
@@ -10,6 +12,7 @@ import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,6 +21,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +33,7 @@ public class BookServiceImpl implements BookService {
 
     @Override
     @Transactional
-    public BookDto createBook(BookCreateRequest request) {
+    public BookDto createBook(BookCreateRequest request, MultipartFile thumbnailImage) {
         String normalizedIsbn = normalizeIsbn(request.isbn());
         validateDuplicateIsbn(normalizedIsbn);
 
@@ -48,6 +52,39 @@ public class BookServiceImpl implements BookService {
     }
 
     @Override
+    public CursorPageResponse<BookDto> getBooks(BookSearchRequest request) {
+        List<BookSearchQueryDto> queryResults = bookRepository.searchBooks(request);
+        long totalElements = bookRepository.countBooks(request);
+
+        boolean hasNext = queryResults.size() > request.limit();
+        List<BookSearchQueryDto> currentPage = hasNext
+                ? queryResults.subList(0, request.limit())
+                : queryResults;
+
+        List<BookDto> content = currentPage.stream()
+                .map(bookMapper::toDto)
+                .toList();
+
+        String nextCursor = null;
+        LocalDateTime nextAfter = null;
+
+        if (hasNext && !currentPage.isEmpty()) {
+            BookSearchQueryDto lastItem = currentPage.get(currentPage.size() - 1);
+            nextCursor = extractNextCursor(lastItem, request.orderBy());
+            nextAfter = lastItem.createdAt();
+        }
+
+        return new CursorPageResponse<>(
+                content,
+                nextCursor,
+                nextAfter,
+                content.size(),
+                totalElements,
+                hasNext
+        );
+    }
+
+    @Override
     public BookDto getBook(UUID bookId) {
         Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
                 .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
@@ -57,7 +94,7 @@ public class BookServiceImpl implements BookService {
 
     @Override
     @Transactional
-    public BookDto updateBook(UUID bookId, BookUpdateRequest request) {
+    public BookDto updateBook(UUID bookId, BookUpdateRequest request, MultipartFile thumbnailImage) {
         Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
                 .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
 
@@ -92,15 +129,25 @@ public class BookServiceImpl implements BookService {
     }
 
     @Override
-    public List<PopularBookDto> searchPopularBooks(Period period, String direction, String cursor,
-        String after, int limit) {
+    public List<PopularBookDto> searchPopularBooks(
+            Period period,
+            String direction,
+            String cursor,
+            String after,
+            int limit
+    ) {
         LocalDateTime startTime = calculateStartTime(period);
         List<PopularBook> popularBooks = bookRepository.findPopularBooksWithPaging(
-            startTime, direction, cursor, after, limit
+                startTime,
+                direction,
+                cursor,
+                after,
+                limit
         );
+
         return popularBooks.stream()
-            .map(bookMapper::toPopularDto)
-            .collect(Collectors.toList());
+                .map(bookMapper::toPopularDto)
+                .collect(Collectors.toList());
     }
 
     private BookDto toBookDto(Book book) {
@@ -133,12 +180,22 @@ public class BookServiceImpl implements BookService {
         return value.trim();
     }
 
+    private String extractNextCursor(BookSearchQueryDto item, String orderBy) {
+        return switch (orderBy) {
+            case "publishedDate" -> item.publishedDate() == null ? "" : item.publishedDate().toString();
+            case "rating" -> String.valueOf(item.rating());
+            case "reviewCount" -> String.valueOf(item.reviewCount());
+            case "title" -> item.title();
+            default -> item.title();
+        };
+    }
+
     private LocalDateTime calculateStartTime(Period period) {
         return switch (period) {
             case DAILY -> LocalDateTime.now().minusDays(1);
             case WEEKLY -> LocalDateTime.now().minusWeeks(1);
             case MONTHLY -> LocalDateTime.now().minusMonths(1);
-            case ALL_TIME -> LocalDateTime.of(2020, 1, 1, 0, 0); // 아주 오래전 시간
+            case ALL_TIME -> LocalDateTime.of(2020, 1, 1, 0, 0);
         };
     }
 }


### PR DESCRIPTION
feat: book 컨트롤러 CRUD 및 목록 조회 API 구조 구현

## 📋 관련 Issue
Closes #{{issue_number}}

## 🔗 Notion Task 링크
- Notion: {{노션 링크}} [BE-28]

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- 도서 등록 API 구현 (multipart/form-data)
- 도서 목록 조회 API 구조 구현 (커서 기반 요청 DTO 적용)
- 도서 상세 조회 API 구현
- 도서 수정 API 구현 (multipart/form-data)
- 도서 논리 삭제 API 구현
- 도서 물리 삭제 API 구현
- 인기 도서 조회 API 기존 구조 유지
- BookService 인터페이스를 컨트롤러 구조에 맞게 재정의

### ♻️ 리팩토링
- 컨트롤러 계층에서 ApiResponse 구조로 통일

## 🧪 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 엔드포인트 정상 매핑 확인

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] 민감 정보 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker GitHub PR 링크 등록
- [x] Task Tracker 상태 완료 처리

## 📎 참고 사항
- 도서 목록 조회의 실제 검색/정렬/커서 페이지네이션 로직은 Repository 단계에서 구현 예정
- 인기 도서 랭킹 기능은 기존 배치 기반 구조를 유지하고 변경하지 않음