### PR TITLE
refactor: 6개 서비스 중복 로직 제거 -> PeriodUtil 단일 통합

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -14,6 +14,7 @@ import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.deokhugam.deokhugam_server.global.util.PeriodUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -136,7 +137,7 @@ public class BookServiceImpl implements BookService {
             String after,
             int limit
     ) {
-        LocalDateTime startTime = calculateStartTime(period);
+        LocalDateTime startTime = PeriodUtil.calculateStartTime(period);
         List<PopularBook> popularBooks = bookRepository.findPopularBooksWithPaging(
                 startTime,
                 direction,
@@ -187,15 +188,6 @@ public class BookServiceImpl implements BookService {
             case "reviewCount" -> String.valueOf(item.reviewCount());
             case "title" -> item.title();
             default -> item.title();
-        };
-    }
-
-    private LocalDateTime calculateStartTime(Period period) {
-        return switch (period) {
-            case DAILY -> LocalDateTime.now().minusDays(1);
-            case WEEKLY -> LocalDateTime.now().minusWeeks(1);
-            case MONTHLY -> LocalDateTime.now().minusMonths(1);
-            case ALL_TIME -> LocalDateTime.of(2020, 1, 1, 0, 0);
         };
     }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/PopularBookService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/PopularBookService.java
@@ -8,6 +8,7 @@ import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.book.repository.PopularBookRepository;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.deokhugam.deokhugam_server.global.util.PeriodUtil;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
@@ -28,7 +29,7 @@ public class PopularBookService {
   @Transactional
   public void calculateAndSaveRanks(Period periodType) {
     LocalDate endDate = LocalDate.now().minusDays(1);
-    LocalDate startDate = getStartDate(periodType, endDate);
+    LocalDate startDate = PeriodUtil.getStartDate(periodType, endDate);
 
     List<BookRankQueryDto> statistics = bookRepository.findBookStatisticsForRanking(startDate, endDate);
 
@@ -63,12 +64,4 @@ public class PopularBookService {
         .toList();
   }
 
-  private LocalDate getStartDate(Period type, LocalDate endDate) {
-    return switch (type) {
-      case DAILY -> endDate;
-      case WEEKLY -> endDate.minusWeeks(1);
-      case MONTHLY -> endDate.minusMonths(1);
-      case ALL_TIME -> LocalDate.of(2000, 1, 1);
-    };
-  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
@@ -1,5 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.review.service;
 
+import static com.deokhugam.deokhugam_server.global.util.PeriodUtil.getStartDate;
+
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.PopularReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewRankQueryDto;
@@ -65,12 +67,4 @@ public class PopularReviewService {
         .toList();
   }
 
-  private LocalDate getStartDate(Period type, LocalDate endDate) {
-    return switch (type) {
-      case DAILY -> endDate;
-      case WEEKLY -> endDate.minusWeeks(1);
-      case MONTHLY -> endDate.minusMonths(1);
-      case ALL_TIME -> LocalDate.of(2000, 1, 1);
-    };
-  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
@@ -18,6 +18,7 @@ import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.deokhugam.deokhugam_server.global.util.PeriodUtil;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -142,21 +143,12 @@ public class ReviewServiceImpl implements ReviewService {
   @Override
   public List<PopularReviewDto> searchPopularReviews(Period period, String direction, String cursor,
       String after, int limit) {
-    LocalDateTime startTime = calculateStartTime(period);
+    LocalDateTime startTime = PeriodUtil.calculateStartTime(period);
     List<PopularReview> popularReviews = reviewRepository.findPopularReviewsWithPaging(
         startTime, direction, cursor, after, limit
     );
     return popularReviews.stream()
         .map(reviewMapper::toPopularDto)
         .collect(Collectors.toList());
-  }
-
-  private LocalDateTime calculateStartTime(Period period) {
-    return switch (period) {
-      case DAILY -> LocalDateTime.now().minusDays(1);
-      case WEEKLY -> LocalDateTime.now().minusWeeks(1);
-      case MONTHLY -> LocalDateTime.now().minusMonths(1);
-      case ALL_TIME -> LocalDateTime.of(2020, 1, 1, 0, 0); // 아주 오래전 시간
-    };
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserService.java
@@ -6,6 +6,7 @@ import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.domain.user.repository.PowerUserRepository;
 import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.deokhugam.deokhugam_server.global.util.PeriodUtil;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
@@ -25,7 +26,7 @@ public class PowerUserService {
   @Transactional
   public void calculateAndSavePowerUserRanks(Period periodType) {
     LocalDate endDate = LocalDate.now().minusDays(1);
-    LocalDate startDate = getStartDate(periodType, endDate);
+    LocalDate startDate = PeriodUtil.getStartDate(periodType, endDate);
 
     List<UserRankQueryDto> statistics = userRepository.findUserActivityStatistics(startDate,
         endDate);
@@ -61,12 +62,4 @@ public class PowerUserService {
     powerUserRepository.saveAll(rankings);
   }
 
-  private LocalDate getStartDate(Period type, LocalDate endDate) {
-    return switch (type) {
-      case DAILY -> endDate;
-      case WEEKLY -> endDate.minusWeeks(1);
-      case MONTHLY -> endDate.minusMonths(1);
-      case ALL_TIME -> LocalDate.of(2000, 1, 1);
-    };
-  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -13,6 +13,7 @@ import com.deokhugam.deokhugam_server.domain.user.entity.User;
 import com.deokhugam.deokhugam_server.domain.user.mapper.UserMapper;
 import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.util.PeriodUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -67,7 +68,7 @@ public class UserServiceImpl implements UserService{
   @Override
   public List<PowerUserDto> findPowerUsers(Period period, String direction, String cursor, String after,
       int limit) {
-    LocalDateTime startTime = calculateStartTime(period);
+    LocalDateTime startTime = PeriodUtil.calculateStartTime(period);
     List<PowerUser> powerUsers = userRepository.findPowerUsersWithPaging(
         startTime, direction, cursor, after, limit
     );
@@ -105,12 +106,4 @@ public class UserServiceImpl implements UserService{
     userRepository.deleteById(userId);
   }
 
-  private LocalDateTime calculateStartTime(Period period) {
-    return switch (period) {
-      case DAILY -> LocalDateTime.now().minusDays(1);
-      case WEEKLY -> LocalDateTime.now().minusWeeks(1);
-      case MONTHLY -> LocalDateTime.now().minusMonths(1);
-      case ALL_TIME -> LocalDateTime.of(2020, 1, 1, 0, 0); // 아주 오래전 시간
-    };
-  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/util/PeriodUtil.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/util/PeriodUtil.java
@@ -1,0 +1,35 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import com.deokhugam.deokhugam_server.global.type.Period;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class PeriodUtil {
+
+  private static final LocalDateTime ALL_TIME_START = LocalDateTime.of(2020, 1, 1, 0, 0);
+  private static final LocalDate ALL_TIME_START_DATE = LocalDate.of(2000, 1, 1);
+
+  private PeriodUtil() {}
+
+  /** Period → LocalDateTime 변환 (조회용) */
+  public static LocalDateTime calculateStartTime(Period period) {
+    return switch (period) {
+      case DAILY    -> LocalDateTime.now().minusDays(1);
+      case WEEKLY   -> LocalDateTime.now().minusWeeks(1);
+      case MONTHLY  -> LocalDateTime.now().minusMonths(1);
+      case ALL_TIME -> ALL_TIME_START;
+    };
+  }
+
+  /** Period → LocalDate 변환 (배치 랭킹 계산용) */
+  public static LocalDate getStartDate(Period period, LocalDate endDate) {
+    return switch (period) {
+      case DAILY    -> endDate;
+      case WEEKLY   -> endDate.minusWeeks(1);
+      case MONTHLY  -> endDate.minusMonths(1);
+      case ALL_TIME -> ALL_TIME_START_DATE;
+    };
+  }
+}
+


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/global-PeriodUtil-3474cdeff67580578d13fa192912456a?source=copy_link

## 🛠️ 작업 내용

### ♻️ 리팩토링
- global/util/PeriodUtil.java 총 6개 서비스에서 중복된 로직을 단일 통합
  - calculateStartTime(Period) - LocalDateTime 반환 통합
  - getStartDate(Period, LocalDate) - LocalDate 반환 


## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [ ] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항


