### PR TITLE
[BE-41]feat: 알림 서비스, 컨트롤러, 이벤트 리스너, 배치 구현

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/batch/NotificationCleanupBatch.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/batch/NotificationCleanupBatch.java
@@ -1,0 +1,22 @@
+package com.deokhugam.deokhugam_server.domain.notification.batch;
+
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationCleanupBatch {
+
+    private final NotificationService notificationService;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupExpiredNotifications() {
+        log.info("[Batch] Notification cleanup started");
+        notificationService.deleteExpiredNotifications();
+        log.info("[Batch] Notification cleanup completed");
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
@@ -1,0 +1,49 @@
+package com.deokhugam.deokhugam_server.domain.notification.controller;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<CursorPageResponse<NotificationDto>> getNotifications(
+        @Valid NotificationSearchRequest request,
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+        request.setUserId(requestUserId);
+        return ResponseEntity.ok(notificationService.getNotifications(request));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<NotificationDto> readNotification(
+        @PathVariable UUID notificationId,
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+        return ResponseEntity.ok(notificationService.readNotification(notificationId, requestUserId));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> readAllNotifications(
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+        notificationService.readAllNotifications(requestUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,77 @@
+package com.deokhugam.deokhugam_server.domain.notification.event;
+
+import com.deokhugam.deokhugam_server.domain.comment.event.CommentCreatedEvent;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewLikedEvent;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewRankedEvent;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentCreated(CommentCreatedEvent event) {
+        Review review = reviewRepository.findByIdAndIsDeletedFalse(event.reviewId())
+            .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
+
+        UUID reviewOwnerId = review.getUser().getId();
+        if (reviewOwnerId.equals(event.commentAuthorId())) {
+            return; // 자신의 리뷰에 자신이 댓글을 달면 알림 생략
+        }
+
+        notificationService.createNotification(
+            event.reviewId(),
+            reviewOwnerId,
+            NotificationType.REVIEW_COMMENTED,
+            "회원님의 리뷰에 댓글이 달렸습니다."
+        );
+    }
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReviewLiked(ReviewLikedEvent event) {
+        if (event.targetUserId().equals(event.likerId())) {
+            return; // 자신의 리뷰에 자신이 좋아요하면 알림 생략
+        }
+
+        notificationService.createNotification(
+            event.reviewId(),
+            event.targetUserId(),
+            NotificationType.REVIEW_LIKED,
+            "회원님의 리뷰에 좋아요가 달렸습니다."
+        );
+    }
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReviewRanked(ReviewRankedEvent event) {
+        String content = String.format(
+            "회원님의 리뷰가 %s 기간 인기 리뷰 %d위에 선정되었습니다.",
+            event.period().name(), event.rank()
+        );
+
+        notificationService.createNotification(
+            event.reviewId(),
+            event.userId(),
+            NotificationType.REVIEW_RANKED,
+            content
+        );
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationService.java
@@ -1,0 +1,20 @@
+package com.deokhugam.deokhugam_server.domain.notification.service;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import java.util.UUID;
+
+public interface NotificationService {
+
+    NotificationDto createNotification(UUID reviewId, UUID userId, NotificationType type, String content);
+
+    NotificationDto readNotification(UUID notificationId, UUID requestUserId);
+
+    void readAllNotifications(UUID userId);
+
+    CursorPageResponse<NotificationDto> getNotifications(NotificationSearchRequest request);
+
+    void deleteExpiredNotifications();
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,86 @@
+package com.deokhugam.deokhugam_server.domain.notification.service;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.mapper.NotificationMapper;
+import com.deokhugam.deokhugam_server.domain.notification.repository.NotificationRepository;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import com.deokhugam.deokhugam_server.global.util.CursorPageUtil;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
+
+    @Override
+    @Transactional
+    public NotificationDto createNotification(UUID reviewId, UUID userId, NotificationType type, String content) {
+        Notification notification = new Notification(reviewId, userId, type, content);
+        return notificationMapper.toDto(notificationRepository.save(notification));
+    }
+
+    @Override
+    @Transactional
+    public NotificationDto readNotification(UUID notificationId, UUID requestUserId) {
+        Notification notification = notificationRepository.findByIdAndIsDeletedFalse(notificationId)
+            .orElseThrow(() -> new DeokhugamException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getUserId().equals(requestUserId)) {
+            throw new DeokhugamException(ErrorCode.NOT_NOTIFICATION_OWNER);
+        }
+
+        notification.markAsRead();
+        return notificationMapper.toDto(notification);
+    }
+
+    @Override
+    @Transactional
+    public void readAllNotifications(UUID userId) {
+        NotificationSearchRequest request = new NotificationSearchRequest();
+        request.setUserId(userId);
+        request.setLimit(Integer.MAX_VALUE);
+
+        List<Notification> notifications = notificationRepository.searchNotifications(request);
+        notifications.stream()
+            .filter(n -> !n.isRead())
+            .forEach(Notification::markAsRead);
+    }
+
+    @Override
+    public CursorPageResponse<NotificationDto> getNotifications(NotificationSearchRequest request) {
+        List<Notification> notifications = notificationRepository.searchNotifications(request);
+        long totalElements = notificationRepository.countByUserId(request.getUserId());
+
+        return CursorPageUtil.toResponse(
+            notifications,
+            request.getLimit(),
+            totalElements,
+            notificationMapper::toDto,
+            n -> n.getId().toString(),
+            Notification::getCreatedAt
+        );
+    }
+
+    @Override
+    @Transactional
+    public void deleteExpiredNotifications() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+        List<Notification> expired = notificationRepository.findExpiredReadNotifications(threshold);
+        if (!expired.isEmpty()) {
+            notificationRepository.deleteAllInBatch(expired);
+        }
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
@@ -6,6 +6,7 @@ import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.PopularReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.review.entity.PopularReview;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewRankedEvent;
 import com.deokhugam.deokhugam_server.domain.review.mapper.ReviewMapper;
 import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
@@ -15,6 +16,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ public class PopularReviewService {
   private final BookRepository bookRepository;
   private final UserRepository userRepository;
   private final ReviewMapper reviewMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public void calculateAndSaveReviewRanks(Period periodType) {
@@ -58,6 +61,16 @@ public class PopularReviewService {
       popularReviewRepository.deleteAllInBatch(existingRankings);
     }
     popularReviewRepository.saveAll(rankings);
+
+    rankings.stream()
+        .filter(r -> r.getRankOrder() <= 10)
+        .forEach(r -> eventPublisher.publishEvent(new ReviewRankedEvent(
+            r.getReview().getId(),
+            r.getReview().getUser().getId(),
+            periodType,
+            r.getRankOrder(),
+            r.getReview().getContent()
+        )));
   }
 
   public List<PopularReviewDto> getPopularReviews(Period periodType, LocalDate date) {


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Notification-Entity-DTO-Repository-3506e443c288819a8888c355b85dedc3?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- NotificationService 인터페이스 및 NotificationServiceImpl 추가 (create/readOne/readAll/getList/deleteExpired)
- NotificationController 추가 (GET /api/notifications, PATCH /{id}/read, PATCH /read-all)
- NotificationEventListener 추가 (CommentCreated/ReviewLiked/ReviewRanked 이벤트 처리)
- NotificationCleanupBatch 추가 (매일 03:00, isRead=true + 7일 경과 알림 자동 삭제)
- PopularReviewService: 인기 순위 top 10 진입 시 ReviewRankedEvent 발행

## 🧪 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [ ] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [ ] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 초안 작업으로 인해 로컬 빌드 시 오류 메세지 출력
- 수정 작업 진행 예정
