### PR TITLE
[BE-28]feat: Notification Service, Controller 구현 (CRUD + 커서 목록)

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification.java
@@ -1,5 +1,0 @@
-package com.deokhugam.deokhugam_server.domain;
-
-public class notification {
-
-}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/batch/NotificationCleanupBatch.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/batch/NotificationCleanupBatch.java
@@ -1,0 +1,22 @@
+package com.deokhugam.deokhugam_server.domain.notification.batch;
+
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationCleanupBatch {
+
+    private final NotificationService notificationService;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupExpiredNotifications() {
+        log.info("[Batch] Notification cleanup started");
+        notificationService.deleteExpiredNotifications();
+        log.info("[Batch] Notification cleanup completed");
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
@@ -27,7 +27,7 @@ public class NotificationController {
         @Valid NotificationSearchRequest request,
         @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
 
-        request.setUserId(requestUserId);
+        request.assignUserId(requestUserId);
         return ResponseEntity.ok(notificationService.getNotifications(request));
     }
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
@@ -1,0 +1,49 @@
+package com.deokhugam.deokhugam_server.domain.notification.controller;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<CursorPageResponse<NotificationDto>> getNotifications(
+        @Valid NotificationSearchRequest request,
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+        request.setUserId(requestUserId);
+        return ResponseEntity.ok(notificationService.getNotifications(request));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<NotificationDto> readNotification(
+        @PathVariable UUID notificationId,
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+        return ResponseEntity.ok(notificationService.readNotification(notificationId, requestUserId));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> readAllNotifications(
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+
+        notificationService.readAllNotifications(requestUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationSearchRequest.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationSearchRequest.java
@@ -4,10 +4,8 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class NotificationSearchRequest {
 
     @NotNull(message = "사용자 ID는 필수 조회 조건입니다.")
@@ -18,4 +16,9 @@ public class NotificationSearchRequest {
 
     private String direction = "DESC";
     private Integer limit = 20;
+
+    // 컨트롤러에서 헤더 기반 userId를 주입할 때만 사용
+    public void assignUserId(UUID userId) {
+        this.userId = userId;
+    }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationSearchRequest.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationSearchRequest.java
@@ -1,0 +1,21 @@
+package com.deokhugam.deokhugam_server.domain.notification.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotificationSearchRequest {
+
+    @NotNull(message = "사용자 ID는 필수 조회 조건입니다.")
+    private UUID userId;
+
+    private String cursor;
+    private LocalDateTime after;
+
+    private String direction = "DESC";
+    private Integer limit = 20;
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/response/NotificationDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/response/NotificationDto.java
@@ -1,0 +1,15 @@
+package com.deokhugam.deokhugam_server.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record NotificationDto(
+    UUID id,
+    UUID reviewId,
+    UUID userId,
+    NotificationType type,
+    String content,
+    boolean isRead,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/response/NotificationDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/response/NotificationDto.java
@@ -1,5 +1,6 @@
 package com.deokhugam.deokhugam_server.domain.notification.dto.response;
 
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
 import java.time.LocalDateTime;
 import java.util.UUID;
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/Notification.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/Notification.java
@@ -1,0 +1,56 @@
+package com.deokhugam.deokhugam_server.domain.notification.entity;
+
+import com.deokhugam.deokhugam_server.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID reviewId;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isRead = false;
+
+    public Notification(UUID reviewId, UUID userId, NotificationType type, String content) {
+        this.reviewId = reviewId;
+        this.userId = userId;
+        this.type = type;
+        this.content = content;
+        this.isRead = false;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/Notification.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/Notification.java
@@ -11,14 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "notification")
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
@@ -47,7 +45,7 @@ public class Notification extends BaseEntity {
         this.userId = userId;
         this.type = type;
         this.content = content;
-        this.isRead = false;
+        // isRead 기본값(false)은 필드 선언부에서 처리
     }
 
     public void markAsRead() {

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/NotificationType.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/NotificationType.java
@@ -1,0 +1,7 @@
+package com.deokhugam.deokhugam_server.domain.notification.entity;
+
+public enum NotificationType {
+    REVIEW_LIKED,
+    REVIEW_COMMENTED,
+    REVIEW_RANKED
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -25,7 +26,7 @@ public class NotificationEventListener {
     private final NotificationService notificationService;
     private final ReviewRepository reviewRepository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentCreated(CommentCreatedEvent event) {
         Review review = reviewRepository.findByIdAndIsDeletedFalse(event.reviewId())
@@ -44,7 +45,7 @@ public class NotificationEventListener {
         );
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReviewLiked(ReviewLikedEvent event) {
         if (event.targetUserId().equals(event.likerId())) {
@@ -59,7 +60,7 @@ public class NotificationEventListener {
         );
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReviewRanked(ReviewRankedEvent event) {
         String content = String.format(

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,77 @@
+package com.deokhugam.deokhugam_server.domain.notification.event;
+
+import com.deokhugam.deokhugam_server.domain.comment.event.CommentCreatedEvent;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewLikedEvent;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewRankedEvent;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentCreated(CommentCreatedEvent event) {
+        Review review = reviewRepository.findByIdAndIsDeletedFalse(event.reviewId())
+            .orElseThrow(() -> new DeokhugamException(ErrorCode.REVIEW_NOT_FOUND));
+
+        UUID reviewOwnerId = review.getUser().getId();
+        if (reviewOwnerId.equals(event.commentAuthorId())) {
+            return; // 자신의 리뷰에 자신이 댓글을 달면 알림 생략
+        }
+
+        notificationService.createNotification(
+            event.reviewId(),
+            reviewOwnerId,
+            NotificationType.REVIEW_COMMENTED,
+            "회원님의 리뷰에 댓글이 달렸습니다."
+        );
+    }
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReviewLiked(ReviewLikedEvent event) {
+        if (event.targetUserId().equals(event.likerId())) {
+            return; // 자신의 리뷰에 자신이 좋아요하면 알림 생략
+        }
+
+        notificationService.createNotification(
+            event.reviewId(),
+            event.targetUserId(),
+            NotificationType.REVIEW_LIKED,
+            "회원님의 리뷰에 좋아요가 달렸습니다."
+        );
+    }
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReviewRanked(ReviewRankedEvent event) {
+        String content = String.format(
+            "회원님의 리뷰가 %s 기간 인기 리뷰 %d위에 선정되었습니다.",
+            event.period().name(), event.rank()
+        );
+
+        notificationService.createNotification(
+            event.reviewId(),
+            event.userId(),
+            NotificationType.REVIEW_RANKED,
+            content
+        );
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/mapper/NotificationMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/mapper/NotificationMapper.java
@@ -1,0 +1,12 @@
+package com.deokhugam.deokhugam_server.domain.notification.mapper;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface NotificationMapper {
+
+    NotificationDto toDto(Notification notification);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,18 @@
+package com.deokhugam.deokhugam_server.domain.notification.repository;
+
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
+
+    Optional<Notification> findByIdAndIsDeletedFalse(UUID id);
+
+    @Query("SELECT n FROM Notification n WHERE n.isRead = true AND n.updatedAt < :threshold AND n.isDeleted = false")
+    List<Notification> findExpiredReadNotifications(@Param("threshold") LocalDateTime threshold);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepository.java
@@ -13,6 +13,11 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
     Optional<Notification> findByIdAndIsDeletedFalse(UUID id);
 
-    @Query("SELECT n FROM Notification n WHERE n.isRead = true AND n.updatedAt < :threshold AND n.isDeleted = false")
+    List<Notification> findAllByUserIdAndIsDeletedFalse(UUID userId);
+
+    @Query("SELECT n FROM Notification n WHERE n.userId = :userId AND n.isRead = false AND n.isDeleted = false")
+    List<Notification> findUnreadByUserId(@Param("userId") UUID userId);
+
+    @Query("SELECT n FROM Notification n WHERE n.isRead = true AND n.createdAt < :threshold AND n.isDeleted = false")
     List<Notification> findExpiredReadNotifications(@Param("threshold") LocalDateTime threshold);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface NotificationRepositoryCustom {
     List<Notification> searchNotifications(NotificationSearchRequest request);
 
     long countByUserId(UUID userId);
+
+    List<Notification> findUnreadByUserId(UUID userId);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.deokhugam.deokhugam_server.domain.notification.repository;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationRepositoryCustom {
+
+    List<Notification> searchNotifications(NotificationSearchRequest request);
+
+    long countByUserId(UUID userId);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImpl.java
@@ -32,6 +32,18 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
     }
 
     @Override
+    public List<Notification> findUnreadByUserId(UUID userId) {
+        return queryFactory
+            .selectFrom(notification)
+            .where(
+                notification.userId.eq(userId),
+                notification.isDeleted.isFalse(),
+                notification.isRead.isFalse()
+            )
+            .fetch();
+    }
+
+    @Override
     public long countByUserId(UUID userId) {
         Long count = queryFactory
             .select(notification.count())

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.deokhugam.deokhugam_server.domain.notification.repository;
+
+import com.deokhugam.deokhugam_server.domain.notification.entity.QNotification.notification;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Notification> searchNotifications(NotificationSearchRequest request) {
+        return queryFactory
+            .selectFrom(notification)
+            .where(
+                notification.userId.eq(request.getUserId()),
+                notification.isDeleted.isFalse(),
+                cursorCondition(request.getAfter(), request.getCursor(), request.getDirection())
+            )
+            .orderBy(orderSpecifier(request.getDirection()))
+            .limit(request.getLimit() + 1)
+            .fetch();
+    }
+
+    @Override
+    public long countByUserId(UUID userId) {
+        Long count = queryFactory
+            .select(notification.count())
+            .from(notification)
+            .where(
+                notification.userId.eq(userId),
+                notification.isDeleted.isFalse()
+            )
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime after, String cursor, String direction) {
+        if (after == null || cursor == null) return null;
+        UUID cursorId = UUID.fromString(cursor);
+        boolean isDesc = !"ASC".equalsIgnoreCase(direction);
+        if (isDesc) {
+            return notification.createdAt.lt(after)
+                .or(notification.createdAt.eq(after).and(notification.id.lt(cursorId)));
+        } else {
+            return notification.createdAt.gt(after)
+                .or(notification.createdAt.eq(after).and(notification.id.gt(cursorId)));
+        }
+    }
+
+    private OrderSpecifier<LocalDateTime> orderSpecifier(String direction) {
+        return "ASC".equalsIgnoreCase(direction)
+            ? notification.createdAt.asc()
+            : notification.createdAt.desc();
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.deokhugam.deokhugam_server.domain.notification.repository;
 
-import com.deokhugam.deokhugam_server.domain.notification.entity.QNotification.notification;
+import static com.deokhugam.deokhugam_server.domain.notification.entity.QNotification.notification;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
 import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationService.java
@@ -1,0 +1,20 @@
+package com.deokhugam.deokhugam_server.domain.notification.service;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import java.util.UUID;
+
+public interface NotificationService {
+
+    NotificationDto createNotification(UUID reviewId, UUID userId, NotificationType type, String content);
+
+    NotificationDto readNotification(UUID notificationId, UUID requestUserId);
+
+    void readAllNotifications(UUID userId);
+
+    CursorPageResponse<NotificationDto> getNotifications(NotificationSearchRequest request);
+
+    void deleteExpiredNotifications();
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
@@ -49,14 +49,8 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     @Transactional
     public void readAllNotifications(UUID userId) {
-        NotificationSearchRequest request = new NotificationSearchRequest();
-        request.setUserId(userId);
-        request.setLimit(Integer.MAX_VALUE);
-
-        List<Notification> notifications = notificationRepository.searchNotifications(request);
-        notifications.stream()
-            .filter(n -> !n.isRead())
-            .forEach(Notification::markAsRead);
+        List<Notification> unread = notificationRepository.findUnreadByUserId(userId);
+        unread.forEach(Notification::markAsRead);
     }
 
     @Override
@@ -79,8 +73,6 @@ public class NotificationServiceImpl implements NotificationService {
     public void deleteExpiredNotifications() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(7);
         List<Notification> expired = notificationRepository.findExpiredReadNotifications(threshold);
-        if (!expired.isEmpty()) {
-            notificationRepository.deleteAllInBatch(expired);
-        }
+        expired.forEach(Notification::delete);
     }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,86 @@
+package com.deokhugam.deokhugam_server.domain.notification.service;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.mapper.NotificationMapper;
+import com.deokhugam.deokhugam_server.domain.notification.repository.NotificationRepository;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import com.deokhugam.deokhugam_server.global.util.CursorPageUtil;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
+
+    @Override
+    @Transactional
+    public NotificationDto createNotification(UUID reviewId, UUID userId, NotificationType type, String content) {
+        Notification notification = new Notification(reviewId, userId, type, content);
+        return notificationMapper.toDto(notificationRepository.save(notification));
+    }
+
+    @Override
+    @Transactional
+    public NotificationDto readNotification(UUID notificationId, UUID requestUserId) {
+        Notification notification = notificationRepository.findByIdAndIsDeletedFalse(notificationId)
+            .orElseThrow(() -> new DeokhugamException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getUserId().equals(requestUserId)) {
+            throw new DeokhugamException(ErrorCode.NOT_NOTIFICATION_OWNER);
+        }
+
+        notification.markAsRead();
+        return notificationMapper.toDto(notification);
+    }
+
+    @Override
+    @Transactional
+    public void readAllNotifications(UUID userId) {
+        NotificationSearchRequest request = new NotificationSearchRequest();
+        request.setUserId(userId);
+        request.setLimit(Integer.MAX_VALUE);
+
+        List<Notification> notifications = notificationRepository.searchNotifications(request);
+        notifications.stream()
+            .filter(n -> !n.isRead())
+            .forEach(Notification::markAsRead);
+    }
+
+    @Override
+    public CursorPageResponse<NotificationDto> getNotifications(NotificationSearchRequest request) {
+        List<Notification> notifications = notificationRepository.searchNotifications(request);
+        long totalElements = notificationRepository.countByUserId(request.getUserId());
+
+        return CursorPageUtil.toResponse(
+            notifications,
+            request.getLimit(),
+            totalElements,
+            notificationMapper::toDto,
+            n -> n.getId().toString(),
+            Notification::getCreatedAt
+        );
+    }
+
+    @Override
+    @Transactional
+    public void deleteExpiredNotifications() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+        List<Notification> expired = notificationRepository.findExpiredReadNotifications(threshold);
+        if (!expired.isEmpty()) {
+            notificationRepository.deleteAllInBatch(expired);
+        }
+    }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
@@ -6,6 +6,7 @@ import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.PopularReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.review.entity.PopularReview;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewRankedEvent;
 import com.deokhugam.deokhugam_server.domain.review.mapper.ReviewMapper;
 import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
@@ -15,6 +16,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ public class PopularReviewService {
   private final BookRepository bookRepository;
   private final UserRepository userRepository;
   private final ReviewMapper reviewMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public void calculateAndSaveReviewRanks(Period periodType) {
@@ -58,6 +61,16 @@ public class PopularReviewService {
       popularReviewRepository.deleteAllInBatch(existingRankings);
     }
     popularReviewRepository.saveAll(rankings);
+
+    rankings.stream()
+        .filter(r -> r.getRankOrder() <= 10)
+        .forEach(r -> eventPublisher.publishEvent(new ReviewRankedEvent(
+            r.getReview().getId(),
+            r.getReview().getUser().getId(),
+            periodType,
+            r.getRankOrder(),
+            r.getReview().getContent()
+        )));
   }
 
   public List<PopularReviewDto> getPopularReviews(Period periodType, LocalDate date) {


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Notification-Service-Controller-CRUD-3506e443c28881288f8bcbcd96568f30?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- NotificationService 인터페이스 및 NotificationServiceImpl 추가(create/readOne/readAll/getList/deleteExpired)
- NotificationController 추가 (GET /api/notifications, PATCH /{id}/read, PATCH /read-all)
- NotificationEventListener 추가 (CommentCreated/ReviewLiked/ReviewRanked 이벤트 처리)
- NotificationCleanupBatch 추가 (매일 03:00, isRead=true + 7일 경과 알림 자동 삭제)
- PopularReviewService: 인기 순위 top 10 진입 시 ReviewRankedEvent 발행

### ♻️ 리팩토링
- Notification: @AllArgsConstructor 제거, 도메인 생성자만 유지
- NotificationSearchRequest: https://github.com/Setter 제거, assignUserId() 메서드로 userId 주입 제한
- NotificationRepository: findUnreadByUserId 추가, 만료 기준 updatedAt → createdAt 변경
- NotificationServiceImpl: readAllNotifications Integer.MAX_VALUE 제거 → 전용 쿼리 사용, deleteExpiredNotifications 물리삭제 → soft delete 적용
- NotificationController: setUserId → assignUserId 호출 변경

### 🐛 버그 수정
- fix(notification): NotificationRepositoryImpl static import 누락 수정
  - import → import static 으로 변경하여 QNotification.notification 정적 필드 참조 오류 해결
- fix(notification): TransactionalEventListener 전파 방식 REQUIRES_NEW로 변경


## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 현재 초안 작성된 상태로 컴파일 오류 리팩토링 예정
- PopularReviewService 로직 추가(수정 / 삭제 없음)

