### PR TITLE
[BE-66, BE-78]fix: 사용자 수정/삭제 API 응답 명세 일치화

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/controller/UserController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/controller/UserController.java
@@ -54,14 +54,14 @@ public class UserController {
   @DeleteMapping("/{userId}")
   public ResponseEntity<Void> delete(@PathVariable UUID userId) {
     userService.deleteSoft(userId);
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
   @Operation(summary = "사용자 정보 수정", description = "사용자의 닉네임을 수정합니다.")
   @PatchMapping("/{userId}")
-  public ResponseEntity<Void> update(@PathVariable UUID userId, @Valid @RequestBody UserUpdateRequest request) {
-    userService.update(userId, request);
-    return ResponseEntity.status(HttpStatus.OK).build();
+  public ResponseEntity<UserDto> update(@PathVariable UUID userId, @Valid @RequestBody UserUpdateRequest request) {
+    UserDto user =  userService.update(userId, request);
+    return ResponseEntity.status(HttpStatus.OK).body(user);
   }
 
   @Operation(summary = "파워 유저 목록 조회", description = "기간별 파워 유저 목록을 조회합니다.")
@@ -84,10 +84,5 @@ public class UserController {
   public ResponseEntity<Void> deleteHard(@PathVariable UUID userId) {
     userService.deleteHard(userId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-  }
-  @PostMapping("/power/calculate")
-  public ResponseEntity<String> triggerCalculate(@RequestParam Period period) {
-    powerUserService.calculateAndSavePowerUserRanks(period);
-    return ResponseEntity.ok(period + " 파워 유저 데이터 생성 완료!");
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserService.java
@@ -18,7 +18,7 @@ public interface UserService {
 
   CursorPageResponse<PowerUserDto> findPowerUsers(Period period, String direction, String cursor, String after, int limit);
 
-  void update(UUID userId, UserUpdateRequest request);
+  UserDto update(UUID userId, UserUpdateRequest request);
 
   void deleteSoft(UUID userId);
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -107,7 +107,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   @Transactional
-  public void update(UUID userId, UserUpdateRequest request) {
+  public UserDto update(UUID userId, UserUpdateRequest request) {
     User user = userRepository.findById(userId).orElseThrow(() ->
         new DeokhugamException(USER_NOT_FOUND));
     if (!user.getNickname().equals(request.nickname())) {
@@ -116,6 +116,7 @@ public class UserServiceImpl implements UserService {
       }
       user.updateNickname(request.nickname());
     }
+    return userMapper.toDto(user);
   }
 
   @Override


### PR DESCRIPTION
## 📋 관련 Issue
[[BE-78] fix(user): 수정/삭제 상태코드 및 응답 바디 수정](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/issues/65#issue-4306373737)
 [[BE-66] chore(api): 명세 미기재 엔드포인트 처리 방침 정의](https://github.com/sprint-sb09-part03-team02/issues/66#/sb09-deokhugam-team02/issues/68) 


## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
User 수정/삭제 상태코드 및 응답 바디 수정
- Notion: https://www.notion.so/User-3506e443c28881dba685c45d2fbee1de?source=copy_link

User 명세 미기재 처리 방침
- Notion: https://www.notion.so/User-3506e443c28881d19deff1b873a3ce54?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

* **API 응답 규격 정규화**: PATCH(수정) 성공 시 `UserDto` 반환(200 OK) 및 DELETE(삭제) 성공 시 상태 코드 `204 No Content` 적용
* **미기재 엔드포인트 제거**: 사용 계획이 없고 문서화되지 않은 `POST /api/users/power/calculate` 및 관련 로직 일체 삭제 (옵션 A 적용)
* **예외 처리 정합성**: 사용자 없음(404), 권한 없음(403), 입력값 오류(400) 등 명세에 따른 예외 응답 확인

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경
