### PR TITLE
Fix: notification 알림 업데이트 경로 정합화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 CLAUDE.md
+AGENTS.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.notification.controller;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
 import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
@@ -9,6 +10,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -31,12 +33,13 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.getNotifications(request));
     }
 
-    @PatchMapping("/{notificationId}/read")
+    @PatchMapping("/{notificationId}")
     public ResponseEntity<NotificationDto> readNotification(
         @PathVariable UUID notificationId,
+        @Valid @RequestBody NotificationUpdateRequest request,
         @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
 
-        return ResponseEntity.ok(notificationService.readNotification(notificationId, requestUserId));
+        return ResponseEntity.ok(notificationService.readNotification(notificationId, requestUserId, request));
     }
 
     @PatchMapping("/read-all")

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationUpdateRequest.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.deokhugam.deokhugam_server.domain.notification.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record NotificationUpdateRequest(
+    @NotNull(message = "알림 읽음 상태는 필수입니다.")
+    Boolean confirmed
+) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/Notification.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/entity/Notification.java
@@ -51,4 +51,8 @@ public class Notification extends BaseEntity {
     public void markAsRead() {
         this.isRead = true;
     }
+
+    public void updateConfirmed(boolean confirmed) {
+        this.isRead = confirmed;
+    }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.notification.service;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
 import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
@@ -10,7 +11,7 @@ public interface NotificationService {
 
     NotificationDto createNotification(UUID reviewId, UUID userId, NotificationType type, String content);
 
-    NotificationDto readNotification(UUID notificationId, UUID requestUserId);
+    NotificationDto readNotification(UUID notificationId, UUID requestUserId, NotificationUpdateRequest request);
 
     void readAllNotifications(UUID userId);
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.notification.service;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
 import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
 import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
@@ -34,7 +35,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     @Transactional
-    public NotificationDto readNotification(UUID notificationId, UUID requestUserId) {
+    public NotificationDto readNotification(UUID notificationId, UUID requestUserId, NotificationUpdateRequest request) {
         Notification notification = notificationRepository.findByIdAndIsDeletedFalse(notificationId)
             .orElseThrow(() -> new DeokhugamException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
@@ -42,7 +43,7 @@ public class NotificationServiceImpl implements NotificationService {
             throw new DeokhugamException(ErrorCode.NOT_NOTIFICATION_OWNER);
         }
 
-        notification.markAsRead();
+        notification.updateConfirmed(request.confirmed());
         return notificationMapper.toDto(notification);
     }
 

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,77 @@
+package com.deokhugam.deokhugam_server.domain.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest {
+
+    private static final String BASE_URL = "/api/notifications";
+    private static final String USER_HEADER = "Deokhugam-Request-User-ID";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    private final UUID notificationId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("성공: 알림 읽음 상태 업데이트는 요청 바디를 받아 처리한다")
+    void updateNotification_Success() throws Exception {
+        NotificationUpdateRequest request = new NotificationUpdateRequest(true);
+        NotificationDto response = new NotificationDto(
+            notificationId,
+            UUID.randomUUID(),
+            userId,
+            NotificationType.REVIEW_COMMENTED,
+            "알림 내용",
+            true,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+        given(notificationService.readNotification(eq(notificationId), eq(userId), any(NotificationUpdateRequest.class)))
+            .willReturn(response);
+
+        mockMvc.perform(patch(BASE_URL + "/{notificationId}", notificationId)
+                .header(USER_HEADER, userId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("실패: 알림 읽음 상태가 없으면 400을 반환한다")
+    void updateNotification_Fail_WhenConfirmedMissing() throws Exception {
+        mockMvc.perform(patch(BASE_URL + "/{notificationId}", notificationId)
+                .header(USER_HEADER, userId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.deokhugam.deokhugam_server.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.mapper.NotificationMapper;
+import com.deokhugam.deokhugam_server.domain.notification.repository.NotificationRepository;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationMapper notificationMapper;
+
+    @Test
+    @DisplayName("성공: confirmed 값에 따라 알림 읽음 상태를 업데이트한다")
+    void readNotification_Success() {
+        UUID notificationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Notification notification = new Notification(UUID.randomUUID(), userId, NotificationType.REVIEW_COMMENTED, "알림");
+        NotificationDto notificationDto = new NotificationDto(
+            notificationId,
+            notification.getReviewId(),
+            userId,
+            notification.getType(),
+            notification.getContent(),
+            false,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+        ReflectionTestUtils.setField(notification, "id", notificationId);
+        notification.markAsRead();
+
+        given(notificationRepository.findByIdAndIsDeletedFalse(notificationId)).willReturn(Optional.of(notification));
+        given(notificationMapper.toDto(notification)).willReturn(notificationDto);
+
+        notificationService.readNotification(notificationId, userId, new NotificationUpdateRequest(false));
+
+        assertThat(notification.isRead()).isFalse();
+    }
+
+    @Test
+    @DisplayName("실패: 알림 소유자가 아니면 예외가 발생한다")
+    void readNotification_Fail_WhenNotOwner() {
+        UUID notificationId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        UUID requestUserId = UUID.randomUUID();
+        Notification notification = new Notification(UUID.randomUUID(), ownerId, NotificationType.REVIEW_COMMENTED, "알림");
+        ReflectionTestUtils.setField(notification, "id", notificationId);
+
+        given(notificationRepository.findByIdAndIsDeletedFalse(notificationId)).willReturn(Optional.of(notification));
+
+        assertThatThrownBy(() ->
+            notificationService.readNotification(notificationId, requestUserId, new NotificationUpdateRequest(true)))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.NOT_NOTIFICATION_OWNER.getMessage());
+    }
+}


### PR DESCRIPTION
## 📋 관련 Issue
Closes #63 

## 🛠️ 작업 내용

### 수정
- PATCH /api/notifications/{notificationId} 경로를 기준 명세에 맞게 정리
- 컨트롤러에서 요청 바디를 받도록 시그니처 수정
- 서비스 메서드 시그니처를 요청 DTO 기반으로 수정

###  기능 추가 / 구현
- NotificationUpdateRequest 생성
- confirmed 값에 따라 알림 읽음 상태를 변경하는 updateConfirmed 로직 추가

### 테스트 추가
- 요청 바디 유효성 검증 테스트 추가
- 알림 소유자 권한 검증 테스트 추가
- confirmed 값 반영 테스트 추가

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 알림 DTO 필드명 명세의 message/confirmed 코드의 content/isRead 와의 차이 존재
