### PR TITLE
[BE-71] fix(user): requestUserId / userId 전달 정책 불일치 이슈

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/controller/UserController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/controller/UserController.java
@@ -45,22 +45,28 @@ public class UserController {
 
   @Operation(summary = "사용자 정보 조회", description = "사용자 ID로 상세 정보를 조회합니다.")
   @GetMapping("/{userId}")
-  public ResponseEntity<UserDto> findById(@PathVariable UUID userId) {
-    UserDto user = userService.find(userId);
+  public ResponseEntity<UserDto> findById(
+    @RequestHeader(value = "Deokhugam-Request-User-ID", required = false) UUID requestUserId,
+    @PathVariable UUID userId) {
+    UserDto user = userService.find(requestUserId,userId);
     return ResponseEntity.status(HttpStatus.OK).body(user);
   }
 
   @Operation(summary = "사용자 논리 삭제", description = "사용자를 논리적으로 삭제합니다.")
   @DeleteMapping("/{userId}")
-  public ResponseEntity<Void> delete(@PathVariable UUID userId) {
-    userService.deleteSoft(userId);
+  public ResponseEntity<Void> delete(
+    @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+    @PathVariable UUID userId) {
+    userService.deleteSoft(requestUserId, userId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
   @Operation(summary = "사용자 정보 수정", description = "사용자의 닉네임을 수정합니다.")
   @PatchMapping("/{userId}")
-  public ResponseEntity<UserDto> update(@PathVariable UUID userId, @Valid @RequestBody UserUpdateRequest request) {
-    UserDto user =  userService.update(userId, request);
+  public ResponseEntity<UserDto> update(
+    @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+    @PathVariable UUID userId, @Valid @RequestBody UserUpdateRequest request) {
+    UserDto user =  userService.update(requestUserId, userId, request);
     return ResponseEntity.status(HttpStatus.OK).body(user);
   }
 
@@ -81,8 +87,10 @@ public class UserController {
 
   @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")
   @DeleteMapping("/{userId}/hard")
-  public ResponseEntity<Void> deleteHard(@PathVariable UUID userId) {
-    userService.deleteHard(userId);
+  public ResponseEntity<Void> deleteHard(
+    @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+    @PathVariable UUID userId) {
+    userService.deleteHard(requestUserId, userId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserService.java
@@ -14,14 +14,14 @@ public interface UserService {
 
   UserDto login(UserLoginRequest request);
 
-  UserDto find(UUID userId);
+  UserDto find( UUID requestUserId, UUID targetUserId);
 
   CursorPageResponse<PowerUserDto> findPowerUsers(Period period, String direction, String cursor, String after, int limit);
 
-  UserDto update(UUID userId, UserUpdateRequest request);
+  UserDto update( UUID requestUserId, UUID targetUserId, UserUpdateRequest request);
 
-  void deleteSoft(UUID userId);
+  void deleteSoft(UUID requestUserId, UUID targetUserId);
 
-  void deleteHard(UUID userId);
+  void deleteHard( UUID requestUserId, UUID targetUserId);
 
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.user.service;
 
 import static com.deokhugam.deokhugam_server.global.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 import com.deokhugam.deokhugam_server.domain.user.dto.request.UserLoginRequest;
 import com.deokhugam.deokhugam_server.domain.user.dto.request.UserRegisterRequest;
@@ -66,10 +67,11 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public UserDto find(UUID userId) {
-    return userRepository.findById(userId)
-        .map(userMapper::toDto)
-        .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
+  public UserDto find(UUID targetUserId, UUID requestUserId) {
+    User user = userRepository.findById(targetUserId)
+      .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
+
+    return userMapper.toDto(user);
   }
 
   @Override
@@ -107,8 +109,9 @@ public class UserServiceImpl implements UserService {
 
   @Override
   @Transactional
-  public UserDto update(UUID userId, UserUpdateRequest request) {
-    User user = userRepository.findById(userId).orElseThrow(() ->
+  public UserDto update(UUID requestUserId, UUID targetUserId, UserUpdateRequest request) {
+    validateOwner(requestUserId, targetUserId);
+    User user = userRepository.findById(targetUserId).orElseThrow(() ->
         new DeokhugamException(USER_NOT_FOUND));
     if (!user.getNickname().equals(request.nickname())) {
       if (userRepository.existsByNickname(request.nickname())) {
@@ -121,19 +124,27 @@ public class UserServiceImpl implements UserService {
 
   @Override
   @Transactional
-  public void deleteSoft(UUID userId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
+  public void deleteSoft(UUID requestUserId, UUID targetUserId) {
+    validateOwner(requestUserId, targetUserId);
+
+    User user = userRepository.findById(targetUserId)
+      .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
+
     user.delete();
 
   }
 
   @Override
-  public void deleteHard(UUID userId) {
-    userRepository.findById(userId)
-        .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
-    userRepository.deleteById(userId);
+  @Transactional
+  public void deleteHard(UUID requestUserId, UUID targetUserId) {
+    validateOwner(requestUserId, targetUserId);
+
+    userRepository.findById(targetUserId)
+      .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
+
+    userRepository.deleteById(targetUserId);
   }
+
   private LocalDateTime parseLocalDateTime(String after) {
     if (after == null || after.isBlank())
       return null;
@@ -145,6 +156,11 @@ public class UserServiceImpl implements UserService {
       return LocalDateTime.parse(after);
     } catch (Exception e) {
       return LocalDate.parse(after.substring(0, 10)).atStartOfDay();
+    }
+  }
+  private void validateOwner(UUID requestUserId, UUID targetUserId) {
+    if (!requestUserId.equals(targetUserId)) {
+      throw new DeokhugamException(HANDLE_ACCESS_DENIED);
     }
   }
 

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
@@ -42,7 +42,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
-
   @Mock
   private UserRepository userRepository;
 
@@ -60,6 +59,7 @@ class UserServiceTest {
 
   private User user;
   private UUID userId;
+  private UUID requestUserId;
 
   private static final String TEST_EMAIL = "test@example.com";
   private static final String TEST_NICKNAME = "tester";
@@ -69,12 +69,13 @@ class UserServiceTest {
   @BeforeEach
   void setUp() {
     userId = UUID.randomUUID();
+    requestUserId = userId;
     user = User.builder()
-      .id(userId)
-      .email(TEST_EMAIL)
-      .nickname(TEST_NICKNAME)
-      .password(ENCODED_PASSWORD)
-      .build();
+        .id(userId)
+        .email(TEST_EMAIL)
+        .nickname(TEST_NICKNAME)
+        .password(ENCODED_PASSWORD)
+        .build();
   }
 
   @Test
@@ -86,29 +87,27 @@ class UserServiceTest {
     given(passwordEncoder.encode(RAW_PASSWORD)).willReturn(ENCODED_PASSWORD);
 
     given(userRepository.save(any(User.class))).willReturn(user);
-    given(userMapper.toDto(any(User.class))).willReturn(
-      new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now()));
+    given(userMapper.toDto(any(User.class))).willReturn(new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now()));
 
     UserDto result = userService.register(request);
 
     assertThat(result.email()).isEqualTo(TEST_EMAIL);
 
     verify(userRepository).save(argThat(savedUser ->
-      savedUser.getEmail().equals(TEST_EMAIL) &&
-        savedUser.getPassword().equals(ENCODED_PASSWORD)
+        savedUser.getEmail().equals(TEST_EMAIL) &&
+            savedUser.getPassword().equals(ENCODED_PASSWORD)
     ));
   }
 
   @Test
   @DisplayName("회원가입 실패 - 이메일 중복")
   void register_fail_duplicateEmail() {
-    UserRegisterRequest request = new UserRegisterRequest("test@example.com", "tester",
-      "password123");
+    UserRegisterRequest request = new UserRegisterRequest("test@example.com", "tester", "password123");
     given(userRepository.existsByEmail(request.email())).willReturn(true);
 
     assertThatThrownBy(() -> userService.register(request))
-      .isInstanceOf(DeokhugamException.class)
-      .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
     verify(userRepository, never()).save(any());
   }
 
@@ -121,7 +120,7 @@ class UserServiceTest {
     given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(user));
     given(passwordEncoder.matches(RAW_PASSWORD, user.getPassword())).willReturn(true);
     given(userMapper.toDto(user)).willReturn(
-      new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now())
+        new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now())
     );
 
     // when
@@ -147,8 +146,8 @@ class UserServiceTest {
 
     // when & then
     assertThatThrownBy(() -> userService.login(request))
-      .isInstanceOf(DeokhugamException.class)
-      .hasMessage(ErrorCode.LOGIN_FAILED.getMessage());
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.LOGIN_FAILED.getMessage());
 
     verify(userMapper, never()).toDto(any());
   }
@@ -164,13 +163,28 @@ class UserServiceTest {
     given(userRepository.existsByNickname(newNickname)).willReturn(false);
 
     // when
-    userService.update(userId, request);
+    userService.update(requestUserId, userId, request);
 
     // then
     assertThat(user.getNickname()).isEqualTo(newNickname);
 
     verify(userRepository).findById(userId);
     verify(userRepository).existsByNickname(newNickname);
+  }
+  @Test
+  @DisplayName("사용자 정보 수정 실패 - 권한 없음")
+  void update_Fail_Forbidden() {
+    UUID otherUserId = UUID.randomUUID(); // 요청자 ≠ 대상
+
+    UserUpdateRequest request = new UserUpdateRequest("newNickname");
+
+    assertThatThrownBy(() ->
+      userService.update(otherUserId, userId, request)
+    )
+      .isInstanceOf(DeokhugamException.class)
+      .hasMessage(ErrorCode.HANDLE_ACCESS_DENIED.getMessage());
+
+    verify(userRepository, never()).findById(any());
   }
 
   @Test
@@ -179,11 +193,11 @@ class UserServiceTest {
     // given
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(userMapper.toDto(user)).willReturn(
-      new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now())
+        new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now())
     );
 
     // when
-    UserDto result = userService.find(userId);
+    UserDto result = userService.find(requestUserId, userId);
 
     // then
     assertThat(result.id()).isEqualTo(userId);
@@ -202,9 +216,9 @@ class UserServiceTest {
     given(userRepository.findById(nonExistentId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> userService.find(nonExistentId))
-      .isInstanceOf(DeokhugamException.class)
-      .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    assertThatThrownBy(() -> userService.find(nonExistentId, nonExistentId))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
     verify(userMapper, never()).toDto(any());
   }
 
@@ -215,7 +229,7 @@ class UserServiceTest {
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
     // when
-    userService.deleteSoft(userId);
+    userService.deleteSoft(requestUserId, userId);
 
     // then
     assertThat(user.isDeleted()).isTrue();
@@ -229,7 +243,7 @@ class UserServiceTest {
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
     // when
-    userService.deleteHard(userId);
+    userService.deleteHard(requestUserId, userId);
 
     // then
     verify(userRepository).findById(userId);
@@ -244,9 +258,9 @@ class UserServiceTest {
     given(userRepository.findById(nonExistentId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> userService.deleteHard(nonExistentId))
-      .isInstanceOf(DeokhugamException.class)
-      .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    assertThatThrownBy(() -> userService.deleteHard(nonExistentId, nonExistentId))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
     verify(userRepository, never()).deleteById(any());
   }
 
@@ -260,18 +274,15 @@ class UserServiceTest {
     ReflectionTestUtils.setField(user1, "createdAt", LocalDateTime.now());
     ReflectionTestUtils.setField(user2, "createdAt", LocalDateTime.now());
 
-    given(powerUserRepository.findPowerUsersByRequirements(eq(Period.MONTHLY), anyString(), any(),
-      any(), any()))
-      .willReturn(List.of(user1, user2));
+    given(powerUserRepository.findPowerUsersByRequirements(eq(Period.MONTHLY), anyString(), any(), any(), any()))
+        .willReturn(List.of(user1, user2));
     given(powerUserRepository.countByPeriodType(Period.MONTHLY)).willReturn(10L);
     given(userMapper.toPowerUserDto(any())).willReturn(
-      new PowerUserDto(userId, "tester", Period.MONTHLY, LocalDateTime.now(), 1, 100.0, 500.0, 10,
-        5)
+        new PowerUserDto(userId, "tester", Period.MONTHLY, LocalDateTime.now(), 1, 100.0, 500.0, 10, 5)
     );
 
     // when
-    CursorPageResponse<PowerUserDto> result = userService.findPowerUsers(Period.MONTHLY, "DESC",
-      null, null, limit);
+    CursorPageResponse<PowerUserDto> result = userService.findPowerUsers(Period.MONTHLY, "DESC", null, null, limit);
 
     // then
     assertThat(result.hasNext()).isTrue();
@@ -279,8 +290,7 @@ class UserServiceTest {
     assertThat(result.nextCursor()).isEqualTo("1");
     assertThat(result.totalElements()).isEqualTo(10L);
 
-    verify(powerUserRepository).findPowerUsersByRequirements(eq(Period.MONTHLY), eq("DESC"), any(),
-      any(), any());
+    verify(powerUserRepository).findPowerUsersByRequirements(eq(Period.MONTHLY), eq("DESC"), any(), any(), any());
     verify(userMapper, atLeastOnce()).toPowerUserDto(any());
   }
 
@@ -292,11 +302,11 @@ class UserServiceTest {
 
     // when & then
     assertThatThrownBy(() ->
-      userService.findPowerUsers(Period.MONTHLY, "DESC", invalidCursor, null, 10)
+        userService.findPowerUsers(Period.MONTHLY, "DESC", invalidCursor, null, 10)
     )
-      .isInstanceOf(DeokhugamException.class)
-      .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
 
     verify(powerUserRepository, never()).findPowerUsersByRequirements(any(), any(), any(), any(), any());
-}
+  }
 }


### PR DESCRIPTION
## 📋 관련 Issue

[[BE-126] fix(user): requestUserId / userId 전달 정책 불일치 이슈](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/issues/66#issue-4306379397)

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion: https://www.notion.so/User-3506e443c288815991fef2f17f8f099f?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

### 🐛 버그 수정
- requestUserId와 userId 전달 정책 불일치로 인한 권한 검증 오류 수정
- 사용자 수정/삭제 시 요청자와 대상자 불일치 시 발생하는 문제 해결

### ✨ 기능 추가 / 구현
- requestUserId 기반 권한 검증 로직 추가
- 사용자 수정/삭제 API에 요청자 검증 로직 적용

### ♻️ 리팩토링
- UserService 메서드 시그니처 변경 (requestUserId, targetUserId 분리)
- validateOwner 메서드 도입으로 권한 검증 로직 공통화
- Controller → Service로 requestUserId 전달 구조 개선

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
-  테스트가 H2로 진행되는데 PostgreSQL 문법을 이해하지 못해 repository 테스트 관련 오류 발생
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-126] fix(user): requestUserId 정책 통일 및 권한 검증 적용`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->
- requestUserId(header) 기준으로 권한 검증을 수행하도록 구조 변경
- 권한 검증 → 존재 여부 검증 순서로 로직 흐름 변경됨에 따라 테스트 코드도 함께 수정
