### PR TITLE
[BE-129,122]fix: Book 명세 api 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/dto/request/BookSearchRequest.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/dto/request/BookSearchRequest.java
@@ -26,7 +26,7 @@ public record BookSearchRequest(
         }
 
         if (limit == null) {
-            limit = 10;
+            limit = 50;
         }
     }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
@@ -19,76 +19,89 @@ import org.hibernate.annotations.UuidGenerator;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Book extends BaseEntity {
 
-    @Id
-    @GeneratedValue
-    @UuidGenerator
-    @Column(name = "id", nullable = false, updatable = false)
-    private UUID id;
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
 
-    @Column(name = "title", nullable = false, length = 255)
-    private String title;
+  @Column(name = "title", nullable = false, length = 255)
+  private String title;
 
-    @Column(name = "author", nullable = false, length = 100)
-    private String author;
+  @Column(name = "author", nullable = false, length = 255)
+  private String author;
 
-    @Column(name = "isbn", nullable = false, unique = true, length = 20)
-    private String isbn;
+  @Column(name = "isbn", nullable = false, unique = true, length = 20)
+  private String isbn;
 
-    @Column(name = "publisher", length = 100)
-    private String publisher;
+  @Column(name = "publisher", length = 255)
+  private String publisher;
 
-    @Column(name = "description", columnDefinition = "text")
-    private String description;
+  @Column(name = "description", columnDefinition = "text")
+  private String description;
 
-    @Column(name = "image_url", length = 500)
-    private String thumbnailUrl;
+  @Column(name = "thumbnail_url", length = 1000)
+  private String thumbnailUrl;
 
-    @Column(name = "published_at", nullable = false)
-    private LocalDate publishedDate;
+  @Column(name = "published_date", nullable = false)
+  private LocalDate publishedDate;
 
-    public Book(
-            String title,
-            String author,
-            String isbn,
-            String publisher,
-            String description,
-            String thumbnailUrl,
-            LocalDate publishedDate
-    ) {
-        this.title = title;
-        this.author = author;
-        this.isbn = isbn;
-        this.publisher = publisher;
-        this.description = description;
-        this.thumbnailUrl = thumbnailUrl;
-        this.publishedDate = publishedDate;
+  @Column(name = "review_count", nullable = false)
+  private int reviewCount;
+
+  @Column(name = "rating", nullable = false)
+  private double rating;
+
+  public Book(
+    String title,
+    String author,
+    String isbn,
+    String publisher,
+    String description,
+    String thumbnailUrl,
+    LocalDate publishedDate
+  ) {
+    this.title = title;
+    this.author = author;
+    this.isbn = isbn;
+    this.publisher = publisher;
+    this.description = description;
+    this.thumbnailUrl = thumbnailUrl;
+    this.publishedDate = publishedDate;
+    this.reviewCount = 0;
+    this.rating = 0.0;
+  }
+
+  public void update(
+    String title,
+    String author,
+    String publisher,
+    String description,
+    String thumbnailUrl,
+    LocalDate publishedDate
+  ) {
+    if (title != null) {
+      this.title = title;
     }
-
-    public void update(
-            String title,
-            String author,
-            String publisher,
-            String description,
-            String thumbnailUrl,
-            LocalDate publishedDate
-    ) {
-        if (title != null) {
-            this.title = title;
-        }
-        if (author != null) {
-            this.author = author;
-        }
-        if (publisher != null) {
-            this.publisher = publisher;
-        }
-        if (description != null) {
-            this.description = description;
-        }
-        if (thumbnailUrl != null) {
-            this.thumbnailUrl = thumbnailUrl;
-        }
-        if (publishedDate != null) {
-            this.publishedDate = publishedDate;
-        }
+    if (author != null) {
+      this.author = author;
     }
+    if (publisher != null) {
+      this.publisher = publisher;
+    }
+    if (description != null) {
+      this.description = description;
+    }
+    if (thumbnailUrl != null) {
+      this.thumbnailUrl = thumbnailUrl;
+    }
+    if (publishedDate != null) {
+      this.publishedDate = publishedDate;
+    }
+  }
+
+  public void updateReviewStatistics(int reviewCount, double rating) {
+    this.reviewCount = reviewCount;
+    this.rating = rating;
+  }
 }


### PR DESCRIPTION

## 📋 관련 Issue
Closes #70 

## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Book-API-34a4cdeff67580c588a0f434bb9a55a6?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
1. 컬럼 매핑 수정 image_url → thumbnail_url
published_at → published_date
2. 스키마 컬럼 반영

DB 스키마에 존재하지만 엔티티에 없던 컬럼 추가

review_count
rating
3. 기본값 설정

DB 기본값과 일치하도록 생성자에서 초기값 설정

reviewCount = 0
rating = 0.0
4. 보조 메서드 추가 updateReviewStatistics(int reviewCount, double rating) 리뷰 집계값 반영을 위한 메서드


## 🧪 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [ ] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [ ] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항

⚠️ 추가 수정 필요 부분

Book.rating 필드 추가로 인해 MapStruct 매핑 충돌 발생

ReviewMapper에 명시적 매핑 추가해야함

ex>>@Mapping(target = "rating", source = "request.rating")

>>>리뷰 평점이 Book이 아닌 ReviewCreateRequest에서 오도록 명확히 지정
