### PR TITLE
[BE-86] Fix: H2 스키마 구성/AWS 업데이트 및 문서 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 application.properties
 application-*.properties
 application-local.yml
+application-local-h2.yml
 application-test.yml
 ### Logs ###
 *.log

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ cd deokhugam
 ./gradlew bootRun --args='--spring.profiles.active=dev'
 ```
 
-**📌 주의:** 환경변수 설정 필수 (자세히: [`deokhugam/docs/AWS_DEPLOYMENT_ENV_VARS.md`](deokhugam/docs/AWS_DEPLOYMENT_ENV_VARS.md))
-
 ## 🧪 테스트 및 커버리지
 
 ```bash
@@ -46,10 +44,3 @@ cd deokhugam
 
 - 커버리지 리포트: `deokhugam/build/reports/jacoco/test/html/index.html`
 - 최소 커버리지 기준: **80%**
-
-## 📚 환경 설정 및 배포
-
-- **[환경 구성 검토 보고서](deokhugam/docs/ENVIRONMENT_CONFIGURATION_REVIEW.md)** — 프로필 분리, 보안 설정
-- **[AWS 배포 환경변수 명세](deokhugam/docs/AWS_DEPLOYMENT_ENV_VARS.md)** — ECS Task Definition, IAM 정책
-- **[로컬/AWS DB 전략](deokhugam/docs/LOCAL_AWS_DB_STRATEGY.md)** — H2 vs PostgreSQL, 마이그레이션 전략
-- **[환경 설정 최종 요약](ENVIRONMENT_SETUP_SUMMARY.md)** — 빠른 시작 가이드

--- a/README.md
+++ b/README.md
@@ -11,10 +11,31 @@
 
 ## 🚀 실행 방법
 
+### 기본: 로컬 H2 환경 (별도 설정 불필요) ⭐ 권장
+
+```bash
+cd deokhugam
+./gradlew bootRun
+```
+
+### 로컬 PostgreSQL 환경
+
+1. `application-local.yml.example`을 참고하여 `application-local.yml` 생성
+2. 본인의 PostgreSQL 정보 입력
+3. 실행:
+```bash
+cd deokhugam
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+### AWS 배포 환경
+
 ```bash
 cd deokhugam
 ./gradlew bootRun --args='--spring.profiles.active=dev'
 ```
+
+**📌 주의:** 환경변수 설정 필수 (자세히: [`deokhugam/docs/AWS_DEPLOYMENT_ENV_VARS.md`](deokhugam/docs/AWS_DEPLOYMENT_ENV_VARS.md))
 
 ## 🧪 테스트 및 커버리지
 
@@ -26,3 +47,9 @@ cd deokhugam
 - 커버리지 리포트: `deokhugam/build/reports/jacoco/test/html/index.html`
 - 최소 커버리지 기준: **80%**
 
+## 📚 환경 설정 및 배포
+
+- **[환경 구성 검토 보고서](deokhugam/docs/ENVIRONMENT_CONFIGURATION_REVIEW.md)** — 프로필 분리, 보안 설정
+- **[AWS 배포 환경변수 명세](deokhugam/docs/AWS_DEPLOYMENT_ENV_VARS.md)** — ECS Task Definition, IAM 정책
+- **[로컬/AWS DB 전략](deokhugam/docs/LOCAL_AWS_DB_STRATEGY.md)** — H2 vs PostgreSQL, 마이그레이션 전략
+- **[환경 설정 최종 요약](ENVIRONMENT_SETUP_SUMMARY.md)** — 빠른 시작 가이드

--- a/deokhugam/Dockerfile
+++ b/deokhugam/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM gradle:8-jdk17-alpine AS builder
+FROM gradle:8-jdk17-jammy AS builder
 
 WORKDIR /app
 
@@ -15,12 +15,12 @@ COPY src ./src
 RUN gradle bootJar --no-daemon -x test
 
 # Stage 2: Run
-FROM eclipse-temurin:17-jre-alpine AS runner
+FROM eclipse-temurin:17-jre-jammy AS runner
 
 WORKDIR /app
 
 # 보안: non-root 사용자 생성
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 
 # 빌드된 JAR 복사 (와일드카드로 버전 무관하게 처리)
 COPY --from=builder /app/build/libs/*.jar app.jar
@@ -43,6 +43,5 @@ ENTRYPOINT ["java", \
     "-XX:+UseContainerSupport", \
     "-XX:MaxRAMPercentage=75.0", \
     "-Djava.security.egd=file:/dev/./urandom", \
-    "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", \
     "-jar", \
     "app.jar"]

--- a/deokhugam/src/main/resources/application-dev.yml
+++ b/deokhugam/src/main/resources/application-dev.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5

--- a/deokhugam/src/main/resources/application-dev.yml
+++ b/deokhugam/src/main/resources/application-dev.yml
@@ -18,10 +18,6 @@ spring:
       hibernate:
         format_sql: false
         dialect: org.hibernate.dialect.PostgreSQLDialect
-  security:
-    user:
-      name: admin
-      password:  ${SPRING_SECURITY_USER_PASSWORD:admin}
 
 cloud:
   aws:
@@ -50,5 +46,5 @@ springdoc:
 
 logging:
   level:
-    com.codeit.deokhugam: INFO
+    com.deokhugam: INFO
     org.hibernate.SQL: OFF

--- a/deokhugam/src/main/resources/application-local.yml.example
+++ b/deokhugam/src/main/resources/application-local.yml.example
@@ -1,0 +1,86 @@
+# 로컬 PostgreSQL 개발 환경 설정 (예시)
+#
+# 📌 사용 방법:
+# 1. 이 파일을 application-local.yml로 복사
+# 2. 본인의 로컬 PostgreSQL 정보로 수정
+# 3. 다음 명령어로 서버 실행: ./gradlew bootRun --args='--spring.profiles.active=local'
+#
+# ⚠️ 주의:
+# - 민감정보(비밀번호, API 키 등)를 포함하므로 Git에 커밋하지 마세요
+# - application-local.yml은 .gitignore에 등록
+# - 공유해야 할 정보는 이 예시 파일만 수정
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/deokhugam
+    username: deokhugam
+    password: deokhugam_1234
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    hibernate:
+      ddl-auto: update          # 로컬에서는 update 권장 (운영은 validate)
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+# ⚠️ AWS 자격증명 주의:
+# - 로컬 개발에서도 AWS 서비스가 필요한 경우:
+#   1. 개인 IAM 사용자를 생성하고 액세스 키 발급
+#   2. ~/.aws/credentials 파일에 설정 (이 파일에 직접 작성하면 안됨)
+#   또는
+#   3. 환경변수로 주입: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# - 이 파일에 액세스 키를 하드코딩하면 절대 안됩니다
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: deokhugam-storage
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+# ⚠️ Naver API 키 주의:
+# - 개인 Naver 애플리케이션 등록 후 Client ID/Secret 발급
+# - 팀 공유 키를 사용하면 안됨
+naver:
+  api:
+    client-id: YOUR_NAVER_CLIENT_ID
+    client-secret: YOUR_NAVER_CLIENT_SECRET
+    url: https://openapi.naver.com/v1/search/book.json
+
+# ⚠️ JWT Secret 주의:
+# - 최소 32자 이상의 랜덤 문자열 사용
+# - 생성 방법: openssl rand -base64 48
+jwt:
+  secret: YOUR_JWT_SECRET_KEY_MINIMUM_32_CHARACTERS
+  expiration: 86400000   # 24시간 (ms)
+
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
+
+logging:
+  level:
+    com.deokhugam: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE
+

--- a/deokhugam/src/main/resources/application.yml
+++ b/deokhugam/src/main/resources/application.yml
@@ -1,6 +1,21 @@
 spring:
   application:
     name: deokhugam
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: never
+
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local-h2}   # 기본값은 즉시 실행 가능한 H2 로컬 프로필
 

--- a/deokhugam/src/main/resources/application.yml
+++ b/deokhugam/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: deokhugam
   profiles:
-    active: local   # 기본값 로컬, ECS는 환경변수 dev로 오버라이드
+    active: ${SPRING_PROFILES_ACTIVE:local-h2}   # 기본값은 즉시 실행 가능한 H2 로컬 프로필
 
 logging:
   pattern:

--- a/deokhugam/src/test/resources/application-test.yml
+++ b/deokhugam/src/test/resources/application-test.yml
@@ -9,9 +9,9 @@ spring:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.H2Dialect
   # 외부 서비스 비활성화
-  data:
-    redis:
-      host: localhost  # TestContainers or embedded 사용
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 
 cloud:
   aws:
@@ -32,5 +32,6 @@ naver:
     url: https://openapi.naver.com/v1/search/book.json
 
 jwt:
-  secret: test-secret-key-for-test-environment-must-be-long-enough
-  expiration: 86400000
+  # 테스트 환경 기본값 (필요시 환경변수로 오버라이드)
+  secret: ${JWT_SECRET:test-secret-key-for-test-environment-must-be-long-enough}
+  expiration: ${JWT_EXPIRATION:86400000}

--- a/deokhugam/src/test/resources/application.yml
+++ b/deokhugam/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  sql:
+    init:
+      mode: never

--- a/task-definition.json
+++ b/task-definition.json
@@ -2,9 +2,9 @@
   "family": "deokhugam-task",
   "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskExecutionRole",
   "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ecsTaskRole",
-  "networkMode": "awsvpc",
+  "networkMode": "bridge",
   "requiresCompatibilities": [
-    "FARGATE"
+    "EC2"
   ],
   "cpu": "512",
   "memory": "1024",
@@ -15,7 +15,7 @@
   "containerDefinitions": [
     {
       "name": "deokhugam-server",
-      "image": "public.ecr.aws/nginx/nginx:latest",
+      "image": "297904677990.dkr.ecr.ap-northeast-2.amazonaws.com/deokhugam-api:latest",
       "essential": true,
       "portMappings": [
         {
@@ -28,20 +28,12 @@
       ],
       "environment": [
         {
-          "name": "DB_USERNAME",
-          "value": "deokhugam"
-        },
-        {
           "name": "AWS_REGION",
           "value": "ap-northeast-2"
         },
         {
           "name": "AWS_S3_BUCKET",
           "value": "deokhugam-storage"
-        },
-        {
-          "name": "DB_URL",
-          "value": "jdbc:postgresql://deokhugam-db.cr0uug8my8f7.ap-northeast-2.rds.amazonaws.com:5432/deokhugam"
         },
         {
           "name": "SPRING_PROFILES_ACTIVE",
@@ -54,8 +46,20 @@
           "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:JWT_SECRET::"
         },
         {
-          "name": "DB_PASSWORD",
-          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:DB_PASSWORD::"
+          "name": "JWT_EXPIRATION",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:JWT_EXPIRATION::"
+        },
+        {
+          "name": "SPRING_DATASOURCE_URL",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:SPRING_DATASOURCE_URL::"
+        },
+        {
+          "name": "SPRING_DATASOURCE_USERNAME",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:SPRING_DATASOURCE_USERNAME::"
+        },
+        {
+          "name": "SPRING_DATASOURCE_PASSWORD",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:SPRING_DATASOURCE_PASSWORD::"
         },
         {
           "name": "NAVER_CLIENT_ID",
@@ -74,18 +78,7 @@
           "awslogs-region": "ap-northeast-2",
           "awslogs-stream-prefix": "ecs"
         }
-      },
-      "healthCheck": {
-        "command": [
-          "CMD-SHELL",
-          "curl -f http://localhost:8080/actuator/health || exit 1"
-        ],
-        "interval": 30,
-        "timeout": 5,
-        "retries": 3,
-        "startPeriod": 120
       }
     }
   ]
 }
-

--- a/task-definition.json
+++ b/task-definition.json
@@ -15,7 +15,7 @@
   "containerDefinitions": [
     {
       "name": "deokhugam-server",
-      "image": "297904677990.dkr.ecr.ap-northeast-2.amazonaws.com/deokhugam-api:latest",
+      "image": "IMAGE_URI",
       "essential": true,
       "portMappings": [
         {

--- a/task-definition.json
+++ b/task-definition.json
@@ -6,8 +6,8 @@
   "requiresCompatibilities": [
     "EC2"
   ],
-  "cpu": "512",
-  "memory": "1024",
+  "cpu": "256",
+  "memory": "512",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/H2-3506e443c28881fdb966e1c3f1452fe2?source=copy_link

## 🛠️ 작업 내용

### ♻️ 리팩토링
- Ubuntu -> Amazon Linux 변경에 따른 dockerfile 변경
- 호환성 보안 강화를 위한 루트 x / 사용자 생성 기능 개선
- 프로젝트 내 프로필 데이터 소스 환경 변수 표준화 및 기존 변수 제거
- 기존 Fargate -> `bridge` 네트워킹 변경 및 기존 이미지 배포로 변경
- 테스트 및 로컬 구성 개선
  - 로컬 개발 옵션 세분화
  - Redis 자동 구성 제외
  - JWT Secret key / time 환경 변수화
  - 테스트 시 SQL 초기화 비활성화

### ⚙️ 설정 변경
- AWS 재설정 관련 민감값 관리 -> AWS Secrets Manager 사용 

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 환경변수 파일 설정 시 `.gitignore`에 필수 등록
- 현재 AWS 관련 수정 중이므로 CI/CD 정상동작 x

