### PR TITLE
Fix: API 계약 알림 DTO 스키마 정렬

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationController.java
@@ -26,10 +26,8 @@ public class NotificationController {
 
     @GetMapping
     public ResponseEntity<CursorPageResponse<NotificationDto>> getNotifications(
-        @Valid NotificationSearchRequest request,
-        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId) {
+        @Valid NotificationSearchRequest request) {
 
-        request.assignUserId(requestUserId);
         return ResponseEntity.ok(notificationService.getNotifications(request));
     }
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationSearchRequest.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/request/NotificationSearchRequest.java
@@ -1,11 +1,16 @@
 package com.deokhugam.deokhugam_server.domain.notification.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class NotificationSearchRequest {
 
     @NotNull(message = "사용자 ID는 필수 조회 조건입니다.")
@@ -14,11 +19,10 @@ public class NotificationSearchRequest {
     private String cursor;
     private LocalDateTime after;
 
+    @Pattern(regexp = "ASC|DESC", message = "정렬 방향은 ASC 또는 DESC만 가능합니다.")
     private String direction = "DESC";
-    private Integer limit = 20;
 
-    // 컨트롤러에서 헤더 기반 userId를 주입할 때만 사용
-    public void assignUserId(UUID userId) {
-        this.userId = userId;
-    }
+    @Min(value = 1, message = "조회 크기는 1 이상이어야 합니다.")
+    @Max(value = 100, message = "조회 크기는 100 이하여야 합니다.")
+    private Integer limit = 20;
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/response/NotificationDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/dto/response/NotificationDto.java
@@ -1,16 +1,15 @@
 package com.deokhugam.deokhugam_server.domain.notification.dto.response;
 
-import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record NotificationDto(
     UUID id,
-    UUID reviewId,
     UUID userId,
-    NotificationType type,
-    String content,
-    boolean isRead,
+    UUID reviewId,
+    String reviewContent,
+    String message,
+    boolean confirmed,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/mapper/NotificationMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/mapper/NotificationMapper.java
@@ -2,11 +2,28 @@ package com.deokhugam.deokhugam_server.domain.notification.mapper;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
 import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
+import java.util.UUID;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface NotificationMapper {
+public abstract class NotificationMapper {
 
-    NotificationDto toDto(Notification notification);
+    @Autowired
+    protected ReviewRepository reviewRepository;
+
+    @Mapping(target = "reviewContent", expression = "java(getReviewContent(notification.getReviewId()))")
+    @Mapping(target = "message", source = "content")
+    @Mapping(target = "confirmed", expression = "java(notification.isRead())")
+    public abstract NotificationDto toDto(Notification notification);
+
+    protected String getReviewContent(UUID reviewId) {
+        return reviewRepository.findByIdAndIsDeletedFalse(reviewId)
+            .map(Review::getContent)
+            .orElse(null);
+    }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImpl.java
@@ -7,6 +7,7 @@ import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
 import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
 import com.deokhugam.deokhugam_server.domain.notification.mapper.NotificationMapper;
 import com.deokhugam.deokhugam_server.domain.notification.repository.NotificationRepository;
+import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
@@ -25,6 +26,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final NotificationMapper notificationMapper;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional
@@ -50,12 +52,14 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     @Transactional
     public void readAllNotifications(UUID userId) {
+        validateUserExists(userId);
         List<Notification> unread = notificationRepository.findUnreadByUserId(userId);
         unread.forEach(Notification::markAsRead);
     }
 
     @Override
     public CursorPageResponse<NotificationDto> getNotifications(NotificationSearchRequest request) {
+        validateUserExists(request.getUserId());
         List<Notification> notifications = notificationRepository.searchNotifications(request);
         long totalElements = notificationRepository.countByUserId(request.getUserId());
 
@@ -75,5 +79,10 @@ public class NotificationServiceImpl implements NotificationService {
         LocalDateTime threshold = LocalDateTime.now().minusDays(7);
         List<Notification> expired = notificationRepository.findExpiredReadNotifications(threshold);
         expired.forEach(Notification::delete);
+    }
+
+    private void validateUserExists(UUID userId) {
+        userRepository.findByIdAndIsDeletedFalse(userId)
+            .orElseThrow(() -> new DeokhugamException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, UUID>, UserRepositoryCustom {
   Optional<User> findByEmail(String email);
 
+  Optional<User> findByIdAndIsDeletedFalse(UUID id);
+
   boolean existsByEmail(String email);
 
   boolean existsByNickname(String nickname);

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/controller/NotificationControllerTest.java
@@ -3,15 +3,18 @@ package com.deokhugam.deokhugam_server.domain.notification.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
-import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
 import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,14 +45,66 @@ class NotificationControllerTest {
     private final UUID userId = UUID.randomUUID();
 
     @Test
+    @DisplayName("성공: 알림 목록 조회는 query userId를 받아 처리한다")
+    void getNotifications_Success() throws Exception {
+        UUID reviewId = UUID.randomUUID();
+        NotificationDto notification = new NotificationDto(
+            notificationId,
+            userId,
+            reviewId,
+            "리뷰 내용",
+            "알림 내용",
+            false,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+        CursorPageResponse<NotificationDto> response = new CursorPageResponse<>(
+            List.of(notification),
+            null,
+            null,
+            1,
+            1L,
+            false
+        );
+        given(notificationService.getNotifications(any())).willReturn(response);
+
+        mockMvc.perform(get(BASE_URL)
+                .param("userId", userId.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].id").value(notificationId.toString()))
+            .andExpect(jsonPath("$.content[0].userId").value(userId.toString()))
+            .andExpect(jsonPath("$.content[0].reviewId").value(reviewId.toString()))
+            .andExpect(jsonPath("$.content[0].reviewContent").value("리뷰 내용"))
+            .andExpect(jsonPath("$.content[0].message").value("알림 내용"))
+            .andExpect(jsonPath("$.content[0].confirmed").value(false));
+    }
+
+    @Test
+    @DisplayName("실패: 알림 목록 조회 시 userId 쿼리가 없으면 400을 반환한다")
+    void getNotifications_Fail_WhenUserIdMissing() throws Exception {
+        mockMvc.perform(get(BASE_URL))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("실패: 알림 목록 조회 시 direction 값이 잘못되면 400을 반환한다")
+    void getNotifications_Fail_WhenDirectionInvalid() throws Exception {
+        mockMvc.perform(get(BASE_URL)
+                .param("userId", userId.toString())
+                .param("direction", "INVALID"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("성공: 알림 읽음 상태 업데이트는 요청 바디를 받아 처리한다")
     void updateNotification_Success() throws Exception {
         NotificationUpdateRequest request = new NotificationUpdateRequest(true);
+        UUID reviewId = UUID.randomUUID();
         NotificationDto response = new NotificationDto(
             notificationId,
-            UUID.randomUUID(),
             userId,
-            NotificationType.REVIEW_COMMENTED,
+            reviewId,
+            "리뷰 내용",
             "알림 내용",
             true,
             LocalDateTime.now(),
@@ -62,7 +117,13 @@ class NotificationControllerTest {
                 .header(USER_HEADER, userId.toString())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk());
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(notificationId.toString()))
+            .andExpect(jsonPath("$.userId").value(userId.toString()))
+            .andExpect(jsonPath("$.reviewId").value(reviewId.toString()))
+            .andExpect(jsonPath("$.reviewContent").value("리뷰 내용"))
+            .andExpect(jsonPath("$.message").value("알림 내용"))
+            .andExpect(jsonPath("$.confirmed").value(true));
     }
 
     @Test
@@ -73,5 +134,13 @@ class NotificationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("성공: 모든 알림 읽음 처리는 헤더 사용자 ID로 처리한다")
+    void readAllNotifications_Success() throws Exception {
+        mockMvc.perform(patch(BASE_URL + "/read-all")
+                .header(USER_HEADER, userId.toString()))
+            .andExpect(status().isNoContent());
     }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImplTest.java
@@ -10,9 +10,14 @@ import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
 import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
 import com.deokhugam.deokhugam_server.domain.notification.mapper.NotificationMapper;
 import com.deokhugam.deokhugam_server.domain.notification.repository.NotificationRepository;
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +40,9 @@ class NotificationServiceImplTest {
     @Mock
     private NotificationMapper notificationMapper;
 
+    @Mock
+    private UserRepository userRepository;
+
     @Test
     @DisplayName("성공: confirmed 값에 따라 알림 읽음 상태를 업데이트한다")
     void readNotification_Success() {
@@ -43,9 +51,9 @@ class NotificationServiceImplTest {
         Notification notification = new Notification(UUID.randomUUID(), userId, NotificationType.REVIEW_COMMENTED, "알림");
         NotificationDto notificationDto = new NotificationDto(
             notificationId,
-            notification.getReviewId(),
             userId,
-            notification.getType(),
+            notification.getReviewId(),
+            "리뷰 내용",
             notification.getContent(),
             false,
             LocalDateTime.now(),
@@ -77,5 +85,64 @@ class NotificationServiceImplTest {
             notificationService.readNotification(notificationId, requestUserId, new NotificationUpdateRequest(true)))
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.NOT_NOTIFICATION_OWNER.getMessage());
+    }
+
+    @Test
+    @DisplayName("성공: 알림 목록 조회 시 사용자 존재를 확인하고 결과를 반환한다")
+    void getNotifications_Success() {
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+        Notification notification = new Notification(UUID.randomUUID(), userId, NotificationType.REVIEW_COMMENTED, "알림");
+        ReflectionTestUtils.setField(notification, "id", notificationId);
+
+        NotificationSearchRequest request = new NotificationSearchRequest();
+        ReflectionTestUtils.setField(request, "userId", userId);
+        ReflectionTestUtils.setField(request, "limit", 20);
+
+        NotificationDto notificationDto = new NotificationDto(
+            notificationId,
+            userId,
+            notification.getReviewId(),
+            "리뷰 내용",
+            notification.getContent(),
+            false,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+
+        given(userRepository.findByIdAndIsDeletedFalse(userId)).willReturn(Optional.of(org.mockito.Mockito.mock(User.class)));
+        given(notificationRepository.searchNotifications(request)).willReturn(List.of(notification));
+        given(notificationRepository.countByUserId(userId)).willReturn(1L);
+        given(notificationMapper.toDto(notification)).willReturn(notificationDto);
+
+        CursorPageResponse<NotificationDto> response = notificationService.getNotifications(request);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).message()).isEqualTo("알림");
+    }
+
+    @Test
+    @DisplayName("실패: 알림 목록 조회 시 사용자가 없으면 예외가 발생한다")
+    void getNotifications_Fail_WhenUserNotFound() {
+        UUID userId = UUID.randomUUID();
+        NotificationSearchRequest request = new NotificationSearchRequest();
+        ReflectionTestUtils.setField(request, "userId", userId);
+
+        given(userRepository.findByIdAndIsDeletedFalse(userId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.getNotifications(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 모든 알림 읽음 처리 시 사용자가 없으면 예외가 발생한다")
+    void readAllNotifications_Fail_WhenUserNotFound() {
+        UUID userId = UUID.randomUUID();
+        given(userRepository.findByIdAndIsDeletedFalse(userId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.readAllNotifications(userId))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## 📋 관련 Issue

Closes #64 

## 🛠️ 작업 내용

### ♻️ 리팩토링
- NotificationDto 응답 필드를 명세서 기준 reviewContent, message, confirmed 형태 정렬
- NotificationMapper에서 content -> message, isRead -> confirmed 매핑 정리 및 reviewId 기반 reviewContent 조회 로직 추가
- GET /api/notifications가 명세대로 query userId를 사용하도록 컨트롤러/요청 DTO 구조 정리
- 알림 목록 조회 및 전체 읽음 처리 시 사용자 존재 여부를 검증하도록 서비스 로직 보강

### ⚙️ 설정 변경
- NotificationSearchRequest에 direction(ASC|DESC) 및 limit(1~100) 검증 추가
- UserRepository에 soft delete 기준 사용자 조회 메서드 추가

## 🧪 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- notification 관련 테스트 실행시 `./gradlew test --tests *`로 통과
