### PR TITLE
[BE-88] User repository 테스트 구현

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/dto/response/UserRankQueryDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/dto/response/UserRankQueryDto.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 public record UserRankQueryDto(
     UUID userId,
-    Double totalReviewScore,
+    Long totalReviewScore,
     Long givenLikeCount,
     Long writtenCommentCount
 ) {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryImplTest.java
@@ -1,0 +1,73 @@
+package com.deokhugam.deokhugam_server.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.deokhugam.deokhugam_server.domain.comment.entity.Comment;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.entity.ReviewLike;
+import com.deokhugam.deokhugam_server.domain.user.dto.response.UserRankQueryDto;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@DataJpaTest
+class UserRepositoryImplTest {
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private EntityManager em;
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+      return new JPAQueryFactory(em);
+    }
+  }
+
+  @Test
+  @DisplayName("지정된 기간 내의 사용자 활동 통계를 정확히 조회한다")
+  void findUserActivityStatisticsTest() {
+    LocalDate start = LocalDate.of(2024, 1, 1);
+    LocalDate end = LocalDate.of(2024, 1, 31);
+
+    User user1 = User.builder().nickname("User1").build();
+    em.persist(user1);
+
+    // 기간 내 활동 생성 (리뷰 2, 좋아요 1, 댓글 1)
+    Review r1 = Review.builder().user(user1).content("Review 1").build(); // createdAt 자동생성 가정
+    Review r2 = Review.builder().user(user1).content("Review 2").build();
+    em.persist(r1);
+    em.persist(r2);
+
+    ReviewLike like1 = ReviewLike.builder().user(user1).review(r1).build();
+    em.persist(like1);
+
+    Comment c1 = Comment.builder().userId(user1.getId()).content("Comment 1").build();
+    em.persist(c1);
+
+    // 2. When
+    List<UserRankQueryDto> results = userRepository.findUserActivityStatistics(start, end);
+    // 3. Then
+    assertThat(results).isNotEmpty();
+    UserRankQueryDto dto = results.stream()
+      .filter(r -> r.userId().equals(user1.getId())) // record는 userId()로 접근
+      .findFirst()
+      .orElseThrow();
+
+    assertThat(dto.totalReviewScore()).isEqualTo(2.0); // count가 Double로 매핑될 경우
+    assertThat(dto.givenLikeCount()).isEqualTo(1L);
+    assertThat(dto.writtenCommentCount()).isEqualTo(1L);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryImplTest.java
@@ -1,8 +1,10 @@
 package com.deokhugam.deokhugam_server.domain.user.repository;
 
+import static com.deokhugam.deokhugam_server.domain.book.entity.QBook.book;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.comment.entity.Comment;
 import com.deokhugam.deokhugam_server.domain.review.entity.Review;
 import com.deokhugam.deokhugam_server.domain.review.entity.ReviewLike;
@@ -18,8 +20,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.TestPropertySource;
 
 @DataJpaTest
+@TestPropertySource(properties = "spring.flyway.enabled=false")
 class UserRepositoryImplTest {
 
   @Autowired
@@ -29,6 +34,7 @@ class UserRepositoryImplTest {
   private EntityManager em;
 
   @TestConfiguration
+  @EnableJpaAuditing
   static class TestConfig {
     @Bean
     public JPAQueryFactory jpaQueryFactory(EntityManager em) {
@@ -39,34 +45,56 @@ class UserRepositoryImplTest {
   @Test
   @DisplayName("지정된 기간 내의 사용자 활동 통계를 정확히 조회한다")
   void findUserActivityStatisticsTest() {
-    LocalDate start = LocalDate.of(2024, 1, 1);
-    LocalDate end = LocalDate.of(2024, 1, 31);
+    // 1. Given: 날짜 설정 (Auditing 반영을 위해 현재 시간 근처로 설정)
+    LocalDate start = LocalDate.now().minusDays(1);
+    LocalDate end = LocalDate.now().plusDays(1);
 
-    User user1 = User.builder().nickname("User1").build();
+    // 사용자 생성
+    User user1 = User.builder()
+      .nickname("User1")
+      .email("test@test.com")
+      .password("1234password!")
+      .build();
     em.persist(user1);
 
-    // 기간 내 활동 생성 (리뷰 2, 좋아요 1, 댓글 1)
-    Review r1 = Review.builder().user(user1).content("Review 1").build(); // createdAt 자동생성 가정
-    Review r2 = Review.builder().user(user1).content("Review 2").build();
+    Book book1 = new Book("테스트 도서 1", "작가1", "isbn-1", "출판사", "설명", "url", LocalDate.now());
+    Book book2 = new Book("테스트 도서 2", "작가2", "isbn-2", "출판사", "설명", "url", LocalDate.now());
+    em.persist(book1);
+    em.persist(book2);
+
+    // 기간 내 활동 생성
+    Review r1 = Review.builder().user(user1).book(book1).content("Review 1").rating(5).build();
+    Review r2 = Review.builder().user(user1).book(book2).content("Review 2").rating(4).build();
     em.persist(r1);
     em.persist(r2);
 
-    ReviewLike like1 = ReviewLike.builder().user(user1).review(r1).build();
+    ReviewLike like1 = ReviewLike.builder()
+      .user(user1)
+      .review(r1)
+      .build();
     em.persist(like1);
 
-    Comment c1 = Comment.builder().userId(user1.getId()).content("Comment 1").build();
+    Comment c1 = Comment.builder()
+      .userId(user1.getId())
+      .review(r1)
+      .content("Comment 1")
+      .build();
     em.persist(c1);
+
+    em.flush();
+    em.clear();
 
     // 2. When
     List<UserRankQueryDto> results = userRepository.findUserActivityStatistics(start, end);
+
     // 3. Then
     assertThat(results).isNotEmpty();
     UserRankQueryDto dto = results.stream()
-      .filter(r -> r.userId().equals(user1.getId())) // record는 userId()로 접근
+      .filter(r -> r.userId().equals(user1.getId()))
       .findFirst()
       .orElseThrow();
 
-    assertThat(dto.totalReviewScore()).isEqualTo(2.0); // count가 Double로 매핑될 경우
+    assertThat(dto.totalReviewScore()).isEqualTo(2L);
     assertThat(dto.givenLikeCount()).isEqualTo(1L);
     assertThat(dto.writtenCommentCount()).isEqualTo(1L);
   }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryImplTest.java
@@ -1,8 +1,6 @@
 package com.deokhugam.deokhugam_server.domain.user.repository;
 
-import static com.deokhugam.deokhugam_server.domain.book.entity.QBook.book;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.comment.entity.Comment;
@@ -31,7 +29,7 @@ class UserRepositoryImplTest {
   private UserRepository userRepository;
 
   @Autowired
-  private EntityManager em;
+  private EntityManager entityManager;
 
   @TestConfiguration
   @EnableJpaAuditing
@@ -44,58 +42,50 @@ class UserRepositoryImplTest {
 
   @Test
   @DisplayName("지정된 기간 내의 사용자 활동 통계를 정확히 조회한다")
-  void findUserActivityStatisticsTest() {
-    // 1. Given: 날짜 설정 (Auditing 반영을 위해 현재 시간 근처로 설정)
+  void findUserActivityStatistics_Success() {
+    //Given
     LocalDate start = LocalDate.now().minusDays(1);
     LocalDate end = LocalDate.now().plusDays(1);
 
-    // 사용자 생성
-    User user1 = User.builder()
-      .nickname("User1")
-      .email("test@test.com")
-      .password("1234password!")
-      .build();
-    em.persist(user1);
+    User user = User.builder().nickname("User1").email("test@test.com").password("1234password!").build();
+    entityManager.persist(user);
 
     Book book1 = new Book("테스트 도서 1", "작가1", "isbn-1", "출판사", "설명", "url", LocalDate.now());
     Book book2 = new Book("테스트 도서 2", "작가2", "isbn-2", "출판사", "설명", "url", LocalDate.now());
-    em.persist(book1);
-    em.persist(book2);
+    entityManager.persist(book1);
+    entityManager.persist(book2);
 
-    // 기간 내 활동 생성
-    Review r1 = Review.builder().user(user1).book(book1).content("Review 1").rating(5).build();
-    Review r2 = Review.builder().user(user1).book(book2).content("Review 2").rating(4).build();
-    em.persist(r1);
-    em.persist(r2);
+    Review r1 = Review.builder().user(user).book(book1).content("Review 1").rating(5).build();
+    Review r2 = Review.builder().user(user).book(book2).content("Review 2").rating(4).build();
+    entityManager.persist(r1);
+    entityManager.persist(r2);
 
-    ReviewLike like1 = ReviewLike.builder()
-      .user(user1)
+    ReviewLike like = ReviewLike.builder()
+      .user(user)
       .review(r1)
       .build();
-    em.persist(like1);
+    entityManager.persist(like);
 
-    Comment c1 = Comment.builder()
-      .userId(user1.getId())
+    Comment comment = Comment.builder()
+      .userId(user.getId())
       .review(r1)
       .content("Comment 1")
       .build();
-    em.persist(c1);
+    entityManager.persist(comment);
 
-    em.flush();
-    em.clear();
+    entityManager.flush();
+    entityManager.clear();
 
-    // 2. When
+    // When
     List<UserRankQueryDto> results = userRepository.findUserActivityStatistics(start, end);
 
-    // 3. Then
-    assertThat(results).isNotEmpty();
-    UserRankQueryDto dto = results.stream()
-      .filter(r -> r.userId().equals(user1.getId()))
-      .findFirst()
-      .orElseThrow();
+    //Then
+    assertThat(results).hasSize(1);
 
-    assertThat(dto.totalReviewScore()).isEqualTo(2L);
-    assertThat(dto.givenLikeCount()).isEqualTo(1L);
-    assertThat(dto.writtenCommentCount()).isEqualTo(1L);
+    UserRankQueryDto actual = results.get(0);
+    assertThat(actual.userId()).isEqualTo(user.getId());
+    assertThat(actual.totalReviewScore()).as("전체 리뷰 수는 2개여야 함").isEqualTo(2L);
+    assertThat(actual.givenLikeCount()).as("전체 좋아요 수는 1개여야 함").isEqualTo(1L);
+    assertThat(actual.writtenCommentCount()).as("전체 댓글 수는 1개여야 함").isEqualTo(1L);
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserServiceTest.java
@@ -52,8 +52,8 @@ class PowerUserServiceTest {
     UUID user1Id = UUID.randomUUID();
     UUID user2Id = UUID.randomUUID();
 
-    UserRankQueryDto user1Stat = new UserRankQueryDto(user1Id, 0.0, 10L, 20L);
-    UserRankQueryDto user2Stat = new UserRankQueryDto(user2Id, 0.0, 50L, 100L);
+    UserRankQueryDto user1Stat = new UserRankQueryDto(user1Id, 0L, 10L, 20L);
+    UserRankQueryDto user2Stat = new UserRankQueryDto(user2Id, 0L, 50L, 100L);
 
     given(userRepository.findUserActivityStatistics(any(), any())).willReturn(List.of(user1Stat, user2Stat));
     given(popularReviewRepository.sumScoreByUserIdAndPeriod(any(), any(), any())).willReturn(Optional.of(0.0));


### PR DESCRIPTION
## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion: https://www.notion.so/User-repository-3506e443c28881359bd2c6e4729bfeea?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

### 🐛 버그 수정
- `UserRankQueryDto`의 필드 타입 불일치 문제 수정 (Long/Double 매핑 오류 해결)

### ✨ 기능 추가 / 구현
- **TDD 기반 유저 활동 통계 기능 구현**: 지정된 기간 내의 리뷰, 좋아요, 댓글 수를 집계하는 기능 추가
- RED-GREEN 사이클을 통한 단위 테스트 기반 기능 검증 완료


## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->
@parksh3070 성호님 도서 컨트롤러 테스트 전체 실패가 떠서 확인 부탁드립니다.
