### PR TITLE
[BE-90] feat: CommentRepository 구현 및 도메인별 테스트 코드 추가

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImpl.java
@@ -24,41 +24,41 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     int pageSize = request.getLimit();
 
     return queryFactory
-        .select(Projections.constructor(CommentDto.class,
-            comment.id,
-            comment.review.id,
-            comment.userId,
-            user.nickname,
-            comment.content,
-            comment.createdAt,
-            comment.updatedAt
-        ))
-        .from(comment)
-        .leftJoin(user).on(comment.userId.eq(user.id))
-        .where(
-            eqReviewId(request.getReviewId()),
-            eqUserId(request.getUserId()),
-            ltCursorAfter(request.getAfter(), request.getCursor()),
-            comment.isDeleted.isFalse()
-        )
-        .orderBy(
-            getOrderSpecifier(request.getDirection()),
-            comment.id.desc()
-        )
-        .limit(pageSize + 1)
-        .fetch();
+      .select(Projections.constructor(CommentDto.class,
+        comment.id,
+        comment.review.id,
+        comment.userId,
+        user.nickname,
+        comment.content,
+        comment.createdAt,
+        comment.updatedAt
+      ))
+      .from(comment)
+      .leftJoin(user).on(comment.userId.eq(user.id))
+      .where(
+        eqReviewId(request.getReviewId()),
+        eqUserId(request.getUserId()),
+        getCursorCondition(request.getAfter(), request.getCursor(), request.getDirection()),
+        comment.isDeleted.isFalse()
+      )
+      .orderBy(
+        getOrderSpecifier(request.getDirection()),
+        comment.id.desc()
+      )
+      .limit(pageSize + 1)
+      .fetch();
   }
 
   @Override
   public long countComments(UUID reviewId) {
     return queryFactory
-        .select(comment.count())
-        .from(comment)
-        .where(
-            eqReviewId(reviewId),
-            comment.isDeleted.isFalse()
-        )
-        .fetchOne();
+      .select(comment.count())
+      .from(comment)
+      .where(
+        eqReviewId(reviewId),
+        comment.isDeleted.isFalse()
+      )
+      .fetchOne();
   }
 
   private BooleanExpression eqReviewId(UUID reviewId) {
@@ -69,12 +69,21 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     return userId != null ? comment.userId.eq(userId) : null;
   }
 
-  private BooleanExpression ltCursorAfter(LocalDateTime after, String cursor) {
+  private BooleanExpression getCursorCondition(LocalDateTime after, String cursor, String direction) {
     if (after == null || cursor == null) return null;
 
-    return comment.createdAt.lt(after)
-        .or(comment.createdAt.eq(after)
-            .and(comment.id.lt(UUID.fromString(cursor))));
+    UUID uuidCursor = UUID.fromString(cursor);
+    boolean isAsc = "ASC".equalsIgnoreCase(direction);
+
+    if (isAsc) {
+      // 오름차순: 커서보다 이후 데이터 (Greater Than)
+      return comment.createdAt.gt(after)
+        .or(comment.createdAt.eq(after).and(comment.id.gt(uuidCursor)));
+    } else {
+      // 내림차순: 커서보다 이전 데이터 (Less Than)
+      return comment.createdAt.lt(after)
+        .or(comment.createdAt.eq(after).and(comment.id.lt(uuidCursor)));
+    }
   }
 
   private OrderSpecifier<LocalDateTime> getOrderSpecifier(String direction) {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/controller/CommentControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/controller/CommentControllerTest.java
@@ -9,6 +9,7 @@ import com.deokhugam.deokhugam_server.domain.comment.dto.request.CommentCreateRe
 import com.deokhugam.deokhugam_server.domain.comment.dto.request.CommentUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.comment.dto.response.CommentDto;
 import com.deokhugam.deokhugam_server.domain.comment.service.CommentService;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +37,7 @@ public class CommentControllerTest {
   private final UUID commentId = UUID.randomUUID();
 
   @Test
-  @DisplayName("성공: 댓글 등록 시 HTTP 201을 반환하고 DTO를 직접 반환한다")
+  @DisplayName("성공: 댓글 등록")
   void createComment_Success() throws Exception {
     CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "댓글 내용");
     CommentDto response = CommentDto.builder().content("댓글 내용").build();
@@ -50,7 +51,44 @@ public class CommentControllerTest {
   }
 
   @Test
-  @DisplayName("성공: 댓글 수정 시 HTTP 200 상태코드를 반환한다")
+  @DisplayName("성공: 리뷰별 댓글 목록 조회 (커서 페이징)")
+  void getCommentsByReviewId_Success() throws Exception {
+    CommentDto dto = CommentDto.builder().content("댓글").build();
+
+    java.util.List<CommentDto> list = new java.util.ArrayList<>();
+    list.add(dto);
+
+    CursorPageResponse<CommentDto> response = new CursorPageResponse<>(
+      list,           // content
+      null,           // nextCursor
+      null,           // nextAfter
+      list.size(),    // size
+      1L,             // totalElements (테스트용 임의 값)
+      false           // hasNext
+    );
+
+    given(commentService.getCommentsByReviewId(any())).willReturn(response);
+
+    mockMvc.perform(get(BASE_URL)
+        .param("reviewId", reviewId.toString())
+        .param("limit", "10"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.content[0].content").value("댓글"));
+  }
+
+  @Test
+  @DisplayName("성공: 댓글 상세 정보 조회")
+  void getComment_Success() throws Exception {
+    CommentDto response = CommentDto.builder().id(commentId).content("조회 내용").build();
+    given(commentService.getComment(commentId)).willReturn(response);
+
+    mockMvc.perform(get(BASE_URL + "/{commentId}", commentId))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.content").value("조회 내용"));
+  }
+
+  @Test
+  @DisplayName("성공: 댓글 수정")
   void updateComment_Success() throws Exception {
     CommentUpdateRequest request = new CommentUpdateRequest("수정 내용");
     CommentDto response = CommentDto.builder().content("수정 내용").build();
@@ -65,7 +103,7 @@ public class CommentControllerTest {
   }
 
   @Test
-  @DisplayName("성공: 댓글 삭제 시 HTTP 204를 반환한다")
+  @DisplayName("성공: 댓글 논리 삭제")
   void deleteComment_Success() throws Exception {
     mockMvc.perform(delete(BASE_URL + "/{commentId}", commentId)
         .header(USER_HEADER, userId.toString()))
@@ -73,13 +111,21 @@ public class CommentControllerTest {
   }
 
   @Test
-  @DisplayName("성공: 댓글 상세 조회")
-  void getComment_Success() throws Exception {
-    CommentDto response = CommentDto.builder().id(commentId).content("조회 내용").build();
-    given(commentService.getComment(commentId)).willReturn(response);
+  @DisplayName("성공: 댓글 물리 삭제")
+  void permanentDeleteComment_Success() throws Exception {
+    mockMvc.perform(delete(BASE_URL + "/{commentId}/hard", commentId)
+        .header(USER_HEADER, userId.toString()))
+      .andExpect(status().isNoContent());
+  }
 
-    mockMvc.perform(get(BASE_URL + "/{commentId}", commentId))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.content").value("조회 내용"));
+  @Test
+  @DisplayName("실패: 댓글 등록 시 내용이 없으면 HTTP 400")
+  void createComment_Validation_Fail() throws Exception {
+    CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "");
+
+    mockMvc.perform(post(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)))
+      .andExpect(status().isBadRequest());
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImplTest.java
@@ -15,16 +15,16 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@Disabled("H2 DB에서 PostgreSQL uuid-ossp 확장 기능 미지원으로 인한 임시 비활성화")
 @DataJpaTest
+@ActiveProfiles("test")
 @Import(QueryDslConfig.class)
 public class CommentRepositoryImplTest {
 
@@ -33,89 +33,63 @@ public class CommentRepositoryImplTest {
 
   private User user;
   private Review review;
-  private Comment commentOld;
-  private Comment commentNew;
+  private UUID commentNewId;
+
+  private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 4, 27, 10, 0, 0);
+  private static final LocalDateTime FIXED_OLD = FIXED_NOW.minusDays(1);
 
   @BeforeEach
   void setUp() {
-    LocalDateTime now = LocalDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS);
-
+    // 1. 유저, 책, 리뷰 생성
     user = User.builder().email("test@test.com").nickname("민주").password("1234").build();
-    ReflectionTestUtils.setField(user, "createdAt", now);
-    ReflectionTestUtils.setField(user, "updatedAt", now);
     em.persist(user);
 
     Book book = new Book("제목", "저자", "ISBN", "출판사", "설명", "url", LocalDate.now());
-    ReflectionTestUtils.setField(book, "createdAt", now);
-    ReflectionTestUtils.setField(book, "updatedAt", now);
     em.persist(book);
 
     review = Review.builder().user(user).book(book).content("리뷰").rating(5).build();
-    ReflectionTestUtils.setField(review, "createdAt", now);
-    ReflectionTestUtils.setField(review, "updatedAt", now);
     em.persist(review);
+    em.flush();
 
-    // 💡 수정됨: reviewId(UUID) 대신 review(객체)를 직접 주입
-    commentOld = Comment.builder()
-      .review(review) // 변경된 부분
-      .userId(user.getId())
-      .content("옛날댓글")
-      .build();
-    ReflectionTestUtils.setField(commentOld, "createdAt", now.minusDays(1));
-    ReflectionTestUtils.setField(commentOld, "updatedAt", now.minusDays(1));
+    // 2. 옛날 댓글 생성
+    Comment commentOld = Comment.builder().review(review).userId(user.getId()).content("옛날댓글").build();
     em.persist(commentOld);
 
-    commentNew = Comment.builder()
-      .review(review) // 변경된 부분
-      .userId(user.getId())
-      .content("최신댓글")
-      .build();
-    ReflectionTestUtils.setField(commentNew, "createdAt", now);
-    ReflectionTestUtils.setField(commentNew, "updatedAt", now);
+    // 3. 최신 댓글 생성
+    Comment commentNew = Comment.builder().review(review).userId(user.getId()).content("최신댓글").build();
     em.persist(commentNew);
+    commentNewId = commentNew.getId();
 
     em.flush();
+
+    em.createNativeQuery("UPDATE comments SET created_at = ?1 WHERE content = ?2")
+      .setParameter(1, FIXED_OLD)
+      .setParameter(2, "옛날댓글")
+      .executeUpdate();
+
+    em.createNativeQuery("UPDATE comments SET created_at = ?1 WHERE content = ?2")
+      .setParameter(1, FIXED_NOW)
+      .setParameter(2, "최신댓글")
+      .executeUpdate();
+
     em.clear();
   }
 
   @Test
-  @DisplayName("성공: 특정 리뷰의 댓글 목록을 조회하면 유저 닉네임이 포함되어야 한다")
-  void searchComments_Join_Success() {
-    CommentSearchRequest request = new CommentSearchRequest();
-    request.setReviewId(review.getId());
-    request.setLimit(10);
-
-    List<CommentDto> result = commentRepository.searchComments(request);
-
-    assertThat(result).hasSize(2);
-    assertThat(result.get(0).userNickname()).isEqualTo("민주");
-    assertThat(result.get(0).content()).isEqualTo("최신댓글");
-  }
-
-  @Test
-  @DisplayName("성공: 특정 유저가 쓴 댓글만 필터링한다")
-  void searchComments_UserFilter_Success() {
-    CommentSearchRequest request = new CommentSearchRequest();
-    request.setReviewId(review.getId());
-    request.setUserId(user.getId());
-    request.setLimit(10);
-
-    List<CommentDto> result = commentRepository.searchComments(request);
-
-    assertThat(result).allMatch(c -> c.userId().equals(user.getId()));
-  }
-
-  @Test
-  @DisplayName("성공: 커서 페이징(ltCursorAfter) 로직이 정상 작동한다")
+  @DisplayName("성공: 커서 페이징 로직이 정상 작동한다")
   void searchComments_Cursor_Success() {
+    // given
     CommentSearchRequest request = new CommentSearchRequest();
     request.setReviewId(review.getId());
-    request.setAfter(commentNew.getCreatedAt());
-    request.setCursor(commentNew.getId().toString());
+    request.setAfter(FIXED_NOW); // 최신댓글 시간 기준
+    request.setCursor(commentNewId.toString());
+    request.setDirection("DESC");
     request.setLimit(10);
 
+    // when
     List<CommentDto> result = commentRepository.searchComments(request);
 
+    // then
     assertThat(result).hasSize(1);
     assertThat(result.get(0).content()).isEqualTo("옛날댓글");
   }
@@ -123,31 +97,43 @@ public class CommentRepositoryImplTest {
   @Test
   @DisplayName("성공: 오름차순(ASC) 정렬이 정상 작동한다")
   void searchComments_SortASC_Success() {
+    // given
     CommentSearchRequest request = new CommentSearchRequest();
     request.setReviewId(review.getId());
     request.setDirection("ASC");
     request.setLimit(10);
 
+    // when
     List<CommentDto> result = commentRepository.searchComments(request);
 
+    // then
+    assertThat(result).isNotEmpty();
     assertThat(result.get(0).content()).isEqualTo("옛날댓글");
+  }
+
+  @Test
+  @DisplayName("성공: 특정 리뷰의 댓글 목록을 조회하면 유저 닉네임이 포함되어야 한다")
+  void searchComments_Join_Success() {
+    // given
+    CommentSearchRequest request = new CommentSearchRequest();
+    request.setReviewId(review.getId());
+    request.setLimit(10);
+
+    // when
+    List<CommentDto> result = commentRepository.searchComments(request);
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.stream().anyMatch(c -> c.userNickname().equals("민주"))).isTrue();
   }
 
   @Test
   @DisplayName("성공: 삭제되지 않은 댓글 수만 카운트한다")
   void countComments_Success() {
+    // when
     long count = commentRepository.countComments(review.getId());
+
+    // then
     assertThat(count).isEqualTo(2);
-  }
-
-  @Test
-  @DisplayName("성공: 검색 조건이 없을 때 ltCursorAfter는 null을 반환하여 무시된다")
-  void ltCursorAfter_Null_Success() {
-    CommentSearchRequest request = new CommentSearchRequest();
-    request.setReviewId(review.getId());
-
-    List<CommentDto> result = commentRepository.searchComments(request);
-
-    assertThat(result).isNotEmpty();
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/controller/ReviewControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/controller/ReviewControllerTest.java
@@ -1,6 +1,8 @@
 package com.deokhugam.deokhugam_server.domain.review.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -8,12 +10,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewCreateRequest;
 import com.deokhugam.deokhugam_server.domain.review.dto.request.ReviewUpdateRequest;
+import com.deokhugam.deokhugam_server.domain.review.dto.response.PopularReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
-import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewLikeDto; // 추가됨
+import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewLikeDto;
 import com.deokhugam.deokhugam_server.domain.review.service.ReviewService;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import com.deokhugam.deokhugam_server.global.type.Period;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -38,68 +48,129 @@ public class ReviewControllerTest {
   private final String BASE_URL = "/api/reviews";
   private final String USER_ID_HEADER = "Deokhugam-Request-User-ID";
 
-  @Test
-  @DisplayName("성공: 리뷰 생성 (201 Created 반환 및 DTO 직접 검증)")
-  void createReview_Success() throws Exception {
-    ReviewCreateRequest request = new ReviewCreateRequest(bookId, userId, "정말 좋아요", 5);
+  @Nested
+  @DisplayName("리뷰 생성 테스트")
+  class CreateReview {
 
-    ReviewDto response = new ReviewDto(
-      reviewId, bookId, "자바의 정석", "url",
-      userId, "테스터", "정말 좋아요", 5,
-      0, 0, false, null, null
-    );
+    @Test
+    @DisplayName("성공: 리뷰 생성 시 201 Created 반환")
+    void createReview_Success() throws Exception {
+      ReviewCreateRequest request = new ReviewCreateRequest(bookId, userId, "최고의 책입니다.", 5);
+      ReviewDto response = new ReviewDto(reviewId, bookId, "제목", "url", userId, "민주", "최고의 책입니다.", 5, 0, 0, false, LocalDateTime.now(), null);
 
-    given(reviewService.createReview(any())).willReturn(response);
+      given(reviewService.createReview(any())).willReturn(response);
 
-    mockMvc.perform(post(BASE_URL)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(request)))
-      .andExpect(status().isCreated())
-      .andExpect(jsonPath("$.content").value("정말 좋아요"));
+      mockMvc.perform(post(BASE_URL)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.content").value("최고의 책입니다."));
+    }
+
+    @Test
+    @DisplayName("실패: 평점이 범위를 벗어나면 400 에러")
+    void createReview_Fail_Rating() throws Exception {
+      ReviewCreateRequest request = new ReviewCreateRequest(bookId, userId, "내용", 6);
+      mockMvc.perform(post(BASE_URL)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+    }
   }
 
-  @Test
-  @DisplayName("성공: 리뷰 상세 조회 (ResponseEntity 반영)")
-  void getReview_Success() throws Exception {
-    ReviewDto response = new ReviewDto(reviewId, bookId, "제목", "url", userId, "닉네임", "내용", 5, 0, 0, false, null, null);
-    given(reviewService.getReview(eq(reviewId), eq(userId))).willReturn(response);
+  @Nested
+  @DisplayName("리뷰 조회 및 검색 테스트")
+  class ReviewSearch {
 
-    mockMvc.perform(get(BASE_URL + "/{reviewId}", reviewId)
-        .header(USER_ID_HEADER, userId.toString()))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.content").value("내용"));
+    @Test
+    @DisplayName("성공: 리뷰 목록 검색 (페이징 반영)")
+    void searchReviews_Success() throws Exception {
+      ReviewDto dto = new ReviewDto(reviewId, bookId, "자바의 정석", "url", userId, "민주", "내용", 5, 0, 0, false, LocalDateTime.now(), null);
+      // CursorPageResponse 생성자 인자 6개 (content, nextCursor, nextAfter, size, totalElements, hasNext)
+      CursorPageResponse<ReviewDto> response = new CursorPageResponse<>(List.of(dto), null, null, 1, 1L, false);
+
+      given(reviewService.searchReviews(any())).willReturn(response);
+
+      mockMvc.perform(get(BASE_URL)
+          .header(USER_ID_HEADER, userId.toString())
+          .param("bookId", bookId.toString())
+          .param("requestUserId", userId.toString())
+          .param("limit", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].bookTitle").value("자바의 정석"));
+    }
+
+    @Test
+    @DisplayName("성공: 리뷰 상세 조회")
+    void getReview_Success() throws Exception {
+      ReviewDto response = new ReviewDto(reviewId, bookId, "제목", "url", userId, "민주", "내용", 5, 0, 0, false, LocalDateTime.now(), null);
+      given(reviewService.getReview(eq(reviewId), eq(userId))).willReturn(response);
+
+      mockMvc.perform(get(BASE_URL + "/{reviewId}", reviewId)
+          .header(USER_ID_HEADER, userId.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value("내용"));
+    }
+
+    @Test
+    @DisplayName("성공: 인기 리뷰 조회")
+    void searchPopularReview_Success() throws Exception {
+      // PopularReviewDto 인자 맞춰서 생성
+      PopularReviewDto dto = new PopularReviewDto(UUID.randomUUID(), reviewId, bookId, "인기 도서", "url", userId, "민주", "내용", 5.0, Period.DAILY, LocalDateTime.now(), 1, 100.0, 10, 5);
+      CursorPageResponse<PopularReviewDto> response = new CursorPageResponse<>(List.of(dto), null, null, 1, 1L, false);
+
+      given(reviewService.searchPopularReviews(any(), anyString(), any(), any(), anyInt())).willReturn(response);
+
+      mockMvc.perform(get(BASE_URL + "/popular")
+          .param("period", "DAILY")
+          .param("direction", "DESC"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].bookTitle").value("인기 도서"));
+    }
   }
 
-  // --- 추가됨: 리뷰 좋아요 테스트 ---
-  @Test
-  @DisplayName("성공: 리뷰 좋아요 추가/취소 (200 OK)")
-  void likeReview_Success() throws Exception {
-    // response의 필드명을 확인하세요.
-    // 만약 ReviewLikeDto에 boolean liked; 라고 되어 있다면 JSON은 "liked"로 나옵니다.
-    ReviewLikeDto response = new ReviewLikeDto(reviewId, userId, true);
-    given(reviewService.likeReview(eq(reviewId), eq(userId))).willReturn(response);
+  @Nested
+  @DisplayName("수정 및 삭제 테스트")
+  class UpdateDelete {
 
-    mockMvc.perform(post(BASE_URL + "/{reviewId}/like", reviewId)
-        .header(USER_ID_HEADER, userId.toString()))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.liked").value(true)); // 💡 $.isLiked에서 $.liked로 수정!
+    @Test
+    @DisplayName("성공: 리뷰 수정 시 200 OK")
+    void updateReview_Success() throws Exception {
+      ReviewUpdateRequest request = new ReviewUpdateRequest("수정 내용", 4);
+      ReviewDto response = new ReviewDto(reviewId, bookId, "제목", "url", userId, "민주", "수정 내용", 4, 0, 0, false, LocalDateTime.now(), null);
+
+      given(reviewService.updateReview(eq(reviewId), any(), eq(userId))).willReturn(response);
+
+      mockMvc.perform(patch(BASE_URL + "/{reviewId}", reviewId)
+          .header(USER_ID_HEADER, userId.toString())
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value("수정 내용"));
+    }
+
+    @Test
+    @DisplayName("성공: 리뷰 삭제 시 204 No Content")
+    void deleteReview_Success() throws Exception {
+      mockMvc.perform(delete(BASE_URL + "/{reviewId}", reviewId)
+          .header(USER_ID_HEADER, userId.toString()))
+        .andExpect(status().isNoContent());
+    }
   }
-  // ----------------------------
 
-  @Test
-  @DisplayName("성공: 인기 리뷰 조회 (복수형 메서드명 반영)")
-  void searchPopularReview_Success() throws Exception {
-    mockMvc.perform(get(BASE_URL + "/popular")
-        .param("period", "DAILY")
-        .param("direction", "DESC")) // 기본값 DESC 반영
-      .andExpect(status().isOk());
-  }
+  @Nested
+  @DisplayName("좋아요 테스트")
+  class LikeReview {
+    @Test
+    @DisplayName("성공: 리뷰 좋아요 토글")
+    void likeReview_Success() throws Exception {
+      ReviewLikeDto response = new ReviewLikeDto(reviewId, userId, true);
+      given(reviewService.likeReview(eq(reviewId), eq(userId))).willReturn(response);
 
-  @Test
-  @DisplayName("성공: 리뷰 삭제 (204 No Content)")
-  void deleteReview_Success() throws Exception {
-    mockMvc.perform(delete(BASE_URL + "/{reviewId}", reviewId)
-        .header(USER_ID_HEADER, userId.toString()))
-      .andExpect(status().isNoContent());
+      mockMvc.perform(post(BASE_URL + "/{reviewId}/like", reviewId)
+          .header(USER_ID_HEADER, userId.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.liked").value(true));
+    }
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImplTest.java
@@ -21,11 +21,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.jupiter.api.Disabled;
 
-@Disabled("H2 DB에서 PostgreSQL uuid-ossp 확장 기능 미지원으로 인한 임시 비활성화")
 @DataJpaTest
+@ActiveProfiles("test")
 @Import(QueryDslConfig.class)
 public class ReviewRepositoryImplTest {
 
@@ -75,7 +76,7 @@ public class ReviewRepositoryImplTest {
     ReviewSearchRequest request = new ReviewSearchRequest();
     request.setKeyword("자바");
     request.setLimit(10);
-    request.setRequestUserId(user.getId()); // 💡 이 줄이 없으면 eq(null) 에러 터짐!
+    request.setRequestUserId(user.getId());
 
     List<ReviewDto> result = reviewRepository.searchReviews(request);
 
@@ -89,7 +90,7 @@ public class ReviewRepositoryImplTest {
     ReviewSearchRequest request = new ReviewSearchRequest();
     request.setKeyword("테스터");
     request.setLimit(10);
-    request.setRequestUserId(user.getId()); // 💡 여기도 반드시 넣어줘야 함
+    request.setRequestUserId(user.getId());
 
     List<ReviewDto> result = reviewRepository.searchReviews(request);
 

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImplTest.java
@@ -3,6 +3,8 @@ package com.deokhugam.deokhugam_server.domain.review.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -63,16 +65,22 @@ class ReviewServiceImplTest {
   private User user;
   private Book book;
   private Review review;
-  private UUID userId = UUID.randomUUID();
-  private UUID bookId = UUID.randomUUID();
-  private UUID reviewId = UUID.randomUUID();
+  private final UUID userId = UUID.randomUUID();
+  private final UUID bookId = UUID.randomUUID();
+  private final UUID reviewId = UUID.randomUUID();
 
   @BeforeEach
   void setUp() {
     user = User.builder().id(userId).nickname("민주").build();
     book = new Book("제목", "저자", "123", "출판사", "설명", "url", LocalDate.now());
     ReflectionTestUtils.setField(book, "id", bookId);
-    review = Review.builder().id(reviewId).user(user).book(book).content("꿀잼").rating(5).build();
+    review = Review.builder()
+      .id(reviewId)
+      .user(user)
+      .book(book)
+      .content("꿀잼")
+      .rating(5)
+      .build();
   }
 
   @Nested
@@ -80,14 +88,43 @@ class ReviewServiceImplTest {
   class ReviewReadWrite {
 
     @Test
+    @DisplayName("생성 성공: 유효한 데이터로 리뷰 등록")
+    void createReview_Success() {
+      ReviewCreateRequest request = new ReviewCreateRequest(bookId, userId, "꿀잼", 5);
+      given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(reviewRepository.existsByBookIdAndUserIdAndIsDeletedFalse(bookId, userId)).willReturn(false);
+      given(reviewMapper.toEntity(any(), any(), any())).willReturn(review);
+      given(reviewRepository.save(any())).willReturn(review);
+      given(reviewMapper.toDto(any(), anyBoolean())).willReturn(new ReviewDto(reviewId, bookId, "제목", "url", userId, "민주", "꿀잼", 5, 0, 0, false, null, null));
+
+      ReviewDto result = reviewService.createReview(request);
+
+      assertThat(result).isNotNull();
+      assertThat(result.content()).isEqualTo("꿀잼");
+      verify(reviewRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("생성 실패: 이미 리뷰를 작성한 도서 (1인 1리뷰 제한)")
+    void createReview_Fail_AlreadyReviewed() {
+      given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(reviewRepository.existsByBookIdAndUserIdAndIsDeletedFalse(bookId, userId)).willReturn(true);
+
+      assertThatThrownBy(() -> reviewService.createReview(new ReviewCreateRequest(bookId, userId, "내용", 5)))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessageContaining(ErrorCode.ALREADY_REVIEWED.getMessage());
+    }
+
+    @Test
     @DisplayName("생성 실패: 도서를 찾을 수 없음")
     void createReview_Fail_BookNotFound() {
       given(bookRepository.findById(bookId)).willReturn(Optional.empty());
 
       assertThatThrownBy(() -> reviewService.createReview(new ReviewCreateRequest(bookId, userId, "내용", 5)))
-          .isInstanceOf(DeokhugamException.class)
-          // .hasMessageContaining("BOOK_NOT_FOUND") 대신 아래처럼 수정!
-          .hasMessageContaining(ErrorCode.BOOK_NOT_FOUND.getMessage());
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessageContaining(ErrorCode.BOOK_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -95,7 +132,7 @@ class ReviewServiceImplTest {
     void getReview_Success() {
       given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
       given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(true);
-      given(reviewMapper.toDto(any(), anyBoolean())).willReturn(new ReviewDto(reviewId, bookId, "제목", "url", userId, "닉네임", "내용", 5, 0, 0, true, null, null));
+      given(reviewMapper.toDto(any(), anyBoolean())).willReturn(new ReviewDto(reviewId, bookId, "제목", "url", userId, "민주", "꿀잼", 5, 0, 0, true, null, null));
 
       ReviewDto result = reviewService.getReview(reviewId, userId);
       assertThat(result.likedByMe()).isTrue();
@@ -105,7 +142,8 @@ class ReviewServiceImplTest {
     @DisplayName("조회 실패: 리뷰 없음")
     void getReview_Fail_NotFound() {
       given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
-      assertThatThrownBy(() -> reviewService.getReview(reviewId, userId)).isInstanceOf(DeokhugamException.class);
+      assertThatThrownBy(() -> reviewService.getReview(reviewId, userId))
+        .isInstanceOf(DeokhugamException.class);
     }
   }
 
@@ -119,8 +157,8 @@ class ReviewServiceImplTest {
       ReviewSearchRequest request = new ReviewSearchRequest();
       request.setLimit(1);
       List<ReviewDto> dtoList = new ArrayList<>(List.of(
-          new ReviewDto(reviewId, bookId, "T1", "U1", userId, "N1", "C1", 5, 0, 0, false, LocalDateTime.now(), null),
-          new ReviewDto(UUID.randomUUID(), bookId, "T2", "U2", userId, "N2", "C2", 4, 0, 0, false, LocalDateTime.now(), null)
+        new ReviewDto(reviewId, bookId, "T1", "U1", userId, "N1", "C1", 5, 0, 0, false, LocalDateTime.now(), null),
+        new ReviewDto(UUID.randomUUID(), bookId, "T2", "U2", userId, "N2", "C2", 4, 0, 0, false, LocalDateTime.now(), null)
       ));
       given(reviewRepository.searchReviews(any())).willReturn(dtoList);
 
@@ -136,7 +174,7 @@ class ReviewServiceImplTest {
       ReflectionTestUtils.setField(pr, "createdAt", LocalDateTime.now());
 
       given(popularReviewRepository.findPopularReviewsWithPaging(any(), anyString(), any(), any(), any(Limit.class)))
-          .willReturn(List.of(pr));
+        .willReturn(List.of(pr));
       given(popularReviewRepository.countByPeriodType(any())).willReturn(1L);
 
       CursorPageResponse<PopularReviewDto> result = reviewService.searchPopularReviews(Period.DAILY, "DESC", "1", "2026-04-21T00:00:00Z", 10);
@@ -157,21 +195,36 @@ class ReviewServiceImplTest {
       given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(otherReview));
 
       assertThatThrownBy(() -> reviewService.updateReview(reviewId, new ReviewUpdateRequest("내용", 5), userId))
-          .isInstanceOf(DeokhugamException.class)
-          .hasMessageContaining(ErrorCode.NOT_REVIEW_OWNER.getMessage());
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessageContaining(ErrorCode.NOT_REVIEW_OWNER.getMessage());
     }
 
     @Test
     @DisplayName("물리 삭제 실패: 리뷰 존재 안 함")
     void hardDeleteReview_Fail_NotFound() {
       given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
-      assertThatThrownBy(() -> reviewService.hardDeleteReview(reviewId, userId)).isInstanceOf(DeokhugamException.class);
+      assertThatThrownBy(() -> reviewService.hardDeleteReview(reviewId, userId))
+        .isInstanceOf(DeokhugamException.class);
     }
   }
 
   @Nested
   @DisplayName("좋아요 토글 테스트")
   class LikeToggle {
+
+    @Test
+    @DisplayName("좋아요 추가 성공: 새 좋아요 저장 및 알림 이벤트 발행")
+    void likeReview_Add_Success() {
+      given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(reviewLikeRepository.findByReviewIdAndUserId(reviewId, userId)).willReturn(Optional.empty());
+
+      ReviewLikeDto result = reviewService.likeReview(reviewId, userId);
+
+      assertThat(result.liked()).isTrue();
+      verify(reviewLikeRepository).save(any());
+      verify(eventPublisher).publishEvent(any(ReviewLikedEvent.class));
+    }
 
     @Test
     @DisplayName("좋아요 취소: 이미 있는 경우 삭제 로직 실행")
@@ -193,7 +246,8 @@ class ReviewServiceImplTest {
       given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
       given(userRepository.findById(userId)).willReturn(Optional.empty());
 
-      assertThatThrownBy(() -> reviewService.likeReview(reviewId, userId)).isInstanceOf(DeokhugamException.class);
+      assertThatThrownBy(() -> reviewService.likeReview(reviewId, userId))
+        .isInstanceOf(DeokhugamException.class);
     }
   }
 }


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Unit-Test-3506e443c28881589436f2be1042cd46?source=copy_link

### 🐛 버그 수정
- Comment 레포지토리도 커서페이징 관련하여 내림차순 오름차순 모두 가능하게 수정했습니다

### 기능추가
- 80퍼 달성을 위해 테스트를 추가했습니다.

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

