### PR TITLE
[BE-92] Feat: 도서 정보 검색용 Naver API, OCR space 통합

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/DeokhugamServerApplication.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/DeokhugamServerApplication.java
@@ -2,9 +2,11 @@ package com.deokhugam.deokhugam_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class DeokhugamServerApplication {
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClient.java
@@ -1,0 +1,101 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+import com.deokhugam.deokhugam_server.domain.book.config.NaverApiProperties;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class NaverBookClient {
+
+  private static final DateTimeFormatter NAVER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]*>");
+
+  private final RestClient.Builder restClientBuilder;
+  private final NaverApiProperties properties;
+
+  public NaverBookDto searchByIsbn(String isbn) {
+    try {
+      NaverBookResponse response = restClientBuilder.build()
+        .get()
+        .uri(properties.url() + "?d_isbn={isbn}", isbn)
+        .header("X-Naver-Client-Id", properties.clientId())
+        .header("X-Naver-Client-Secret", properties.clientSecret())
+        .retrieve()
+        .body(NaverBookResponse.class);
+
+      if (response == null || response.items().isEmpty()) {
+        throw new DeokhugamException(ErrorCode.BOOK_INFO_NOT_FOUND);
+      }
+
+      return response.items().stream()
+        .filter(item -> item.normalizedIsbn().contains(isbn))
+        .findFirst()
+        .or(() -> response.items().stream().findFirst())
+        .map(this::toDto)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_INFO_NOT_FOUND));
+    } catch (DeokhugamException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new DeokhugamException(ErrorCode.BOOK_INFO_NOT_FOUND);
+    }
+  }
+
+  private NaverBookDto toDto(NaverBookItem item) {
+    return new NaverBookDto(
+      clean(item.title()),
+      clean(item.author()),
+      clean(item.description()),
+      clean(item.publisher()),
+      parsePublishedDate(item.pubdate()),
+      item.normalizedIsbn(),
+      item.image()
+    );
+  }
+
+  private LocalDate parsePublishedDate(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+
+    return LocalDate.parse(value, NAVER_DATE_FORMAT);
+  }
+
+  private String clean(String value) {
+    if (value == null) {
+      return null;
+    }
+    return HTML_TAG_PATTERN.matcher(value).replaceAll("").trim();
+  }
+
+  private record NaverBookResponse(
+    List<NaverBookItem> items
+  ) {
+    private NaverBookResponse {
+      items = items == null ? List.of() : items;
+    }
+  }
+
+  private record NaverBookItem(
+    String title,
+    String image,
+    String author,
+    String publisher,
+    String pubdate,
+    String isbn,
+    String description
+  ) {
+    private String normalizedIsbn() {
+      return isbn == null ? "" : isbn.replaceAll("[^0-9Xx]", "");
+    }
+  }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/OcrSpaceClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/OcrSpaceClient.java
@@ -1,0 +1,77 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+import com.deokhugam.deokhugam_server.domain.book.config.OcrSpaceProperties;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class OcrSpaceClient {
+
+  private final RestClient.Builder restClientBuilder;
+  private final OcrSpaceProperties properties;
+
+  public String parseText(MultipartFile image) {
+    try {
+      MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+      body.add("apikey", properties.key());
+      body.add("language", "eng");
+      body.add("isOverlayRequired", "false");
+      body.add("file", image.getResource());
+
+      OcrSpaceResponse response = restClientBuilder.build()
+        .post()
+        .uri(properties.url())
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .body(body)
+        .retrieve()
+        .body(OcrSpaceResponse.class);
+
+      if (response == null || response.isErroredOnProcessing()) {
+        throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
+      }
+
+      String parsedText = response.parsedResults().stream()
+        .map(OcrParsedResult::parsedText)
+        .filter(text -> text != null && !text.isBlank())
+        .reduce("", (left, right) -> left + "\n" + right)
+        .trim();
+
+      if (parsedText.isBlank()) {
+        throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
+      }
+
+      return parsedText;
+    } catch (DeokhugamException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
+    }
+  }
+
+  private record OcrSpaceResponse(
+    @JsonProperty("ParsedResults")
+    List<OcrParsedResult> parsedResults,
+    @JsonProperty("IsErroredOnProcessing")
+    boolean isErroredOnProcessing
+  ) {
+    private OcrSpaceResponse {
+      parsedResults = parsedResults == null ? List.of() : parsedResults;
+    }
+  }
+
+  private record OcrParsedResult(
+    @JsonProperty("ParsedText")
+    String parsedText
+  ) {
+  }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/config/NaverApiProperties.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/config/NaverApiProperties.java
@@ -1,0 +1,11 @@
+package com.deokhugam.deokhugam_server.domain.book.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "naver.api")
+public record NaverApiProperties(
+  String clientId,
+  String clientSecret,
+  String url
+) {
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/config/OcrSpaceProperties.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/config/OcrSpaceProperties.java
@@ -1,0 +1,10 @@
+package com.deokhugam.deokhugam_server.domain.book.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "ocr-space.api")
+public record OcrSpaceProperties(
+  String key,
+  String url
+) {
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
@@ -49,6 +49,18 @@ public class BookController {
     return ResponseEntity.ok(response);
   }
 
+  @PostMapping(value = "/isbn/ocr", consumes = "multipart/form-data")
+  public ResponseEntity<String> extractIsbn(@RequestParam MultipartFile image) {
+    String isbn = bookService.extractIsbn(image);
+    return ResponseEntity.ok(isbn);
+  }
+
+  @GetMapping("/info")
+  public ResponseEntity<NaverBookDto> getBookInfo(@RequestParam String isbn) {
+    NaverBookDto response = bookService.getBookInfo(isbn);
+    return ResponseEntity.ok(response);
+  }
+
   @GetMapping("/{bookId}")
   public ResponseEntity<BookDto> getBook(@PathVariable UUID bookId) {
     BookDto response = bookService.getBook(bookId);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -9,6 +9,8 @@ import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
+import com.deokhugam.deokhugam_server.domain.book.client.NaverBookClient;
+import com.deokhugam.deokhugam_server.domain.book.client.OcrSpaceClient;
 import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.book.repository.PopularBookRepository;
@@ -47,6 +49,8 @@ public class BookServiceImpl implements BookService {
   private final BookRepository bookRepository;
   private final BookMapper bookMapper;
   private final PopularBookRepository popularBookRepository;
+  private final OcrSpaceClient ocrSpaceClient;
+  private final NaverBookClient naverBookClient;
 
   @Override
   @Transactional
@@ -107,12 +111,8 @@ public class BookServiceImpl implements BookService {
   public String extractIsbn(MultipartFile image) {
     validateImageFile(image);
 
-    String originalFilename = image.getOriginalFilename();
-    if (originalFilename == null || originalFilename.isBlank()) {
-      throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
-    }
-
-    String extractedIsbn = extractIsbnFromText(originalFilename);
+    String ocrText = ocrSpaceClient.parseText(image);
+    String extractedIsbn = extractIsbnFromText(ocrText);
     if (extractedIsbn == null) {
       throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
     }
@@ -204,19 +204,7 @@ public class BookServiceImpl implements BookService {
   @Override
   public NaverBookDto getBookInfo(String isbn) {
     String normalizedIsbn = normalizeIsbn(isbn);
-
-    Book book = bookRepository.findByIsbnAndIsDeletedFalse(normalizedIsbn)
-      .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_INFO_NOT_FOUND));
-
-    return new NaverBookDto(
-      book.getTitle(),
-      book.getAuthor(),
-      book.getDescription(),
-      book.getPublisher(),
-      book.getPublishedDate(),
-      book.getIsbn(),
-      book.getThumbnailUrl()
-    );
+    return naverBookClient.searchByIsbn(normalizedIsbn);
   }
 
   @Override

--- a/deokhugam/src/main/resources/application-dev.yml
+++ b/deokhugam/src/main/resources/application-dev.yml
@@ -32,7 +32,12 @@ naver:
   api:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
-    url: https://openapi.naver.com/v1/search/book.json
+    url: https://openapi.naver.com/v1/search/book_adv.json
+
+ocr-space:
+  api:
+    key: ${OCR_SPACE_API_KEY}
+    url: https://api.ocr.space/parse/image
 
 jwt:
   secret: ${JWT_SECRET}

--- a/deokhugam/src/main/resources/application-local.yml.example
+++ b/deokhugam/src/main/resources/application-local.yml.example
@@ -63,7 +63,12 @@ naver:
   api:
     client-id: YOUR_NAVER_CLIENT_ID
     client-secret: YOUR_NAVER_CLIENT_SECRET
-    url: https://openapi.naver.com/v1/search/book.json
+    url: https://openapi.naver.com/v1/search/book_adv.json
+
+ocr-space:
+  api:
+    key: YOUR_OCR_SPACE_API_KEY
+    url: https://api.ocr.space/parse/image
 
 # ⚠️ JWT Secret 주의:
 # - 최소 32자 이상의 랜덤 문자열 사용
@@ -83,4 +88,3 @@ logging:
     com.deokhugam: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql: TRACE
-

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/controller/BookControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/controller/BookControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -80,13 +81,11 @@ class BookControllerTest {
         .param("publisher", "인사이트")
         .param("description", "설명")
         .param("publishedDate", "2024-01-01"))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(201))
-      .andExpect(jsonPath("$.data.id").value(bookId.toString()))
-      .andExpect(jsonPath("$.data.title").value("클린 코드"))
-      .andExpect(jsonPath("$.data.author").value("로버트 마틴"))
-      .andExpect(jsonPath("$.data.isbn").value("9788912345678"));
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.id").value(bookId.toString()))
+      .andExpect(jsonPath("$.title").value("클린 코드"))
+      .andExpect(jsonPath("$.author").value("로버트 마틴"))
+      .andExpect(jsonPath("$.isbn").value("9788912345678"));
   }
 
   @Test
@@ -127,12 +126,10 @@ class BookControllerTest {
         .param("direction", "DESC")
         .param("limit", "10"))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(200))
-      .andExpect(jsonPath("$.data.content[0].id").value(bookId.toString()))
-      .andExpect(jsonPath("$.data.content[0].title").value("책 제목"))
-      .andExpect(jsonPath("$.data.totalElements").value(1))
-      .andExpect(jsonPath("$.data.hasNext").value(false));
+      .andExpect(jsonPath("$.content[0].id").value(bookId.toString()))
+      .andExpect(jsonPath("$.content[0].title").value("책 제목"))
+      .andExpect(jsonPath("$.totalElements").value(1))
+      .andExpect(jsonPath("$.hasNext").value(false));
   }
 
   @Test
@@ -150,9 +147,7 @@ class BookControllerTest {
     mockMvc.perform(multipart("/api/books/isbn/ocr")
         .file(image))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(200))
-      .andExpect(jsonPath("$.data").value("9788912345678"));
+      .andExpect(content().string("9788912345678"));
   }
 
   @Test
@@ -180,11 +175,10 @@ class BookControllerTest {
 
     mockMvc.perform(get("/api/books/{bookId}", bookId))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.data.id").value(bookId.toString()))
-      .andExpect(jsonPath("$.data.title").value("책 제목"))
-      .andExpect(jsonPath("$.data.reviewCount").value(3))
-      .andExpect(jsonPath("$.data.rating").value(4.5));
+      .andExpect(jsonPath("$.id").value(bookId.toString()))
+      .andExpect(jsonPath("$.title").value("책 제목"))
+      .andExpect(jsonPath("$.reviewCount").value(3))
+      .andExpect(jsonPath("$.rating").value(4.5));
   }
 
   @Test
@@ -229,11 +223,9 @@ class BookControllerTest {
           return request;
         }))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(200))
-      .andExpect(jsonPath("$.data.id").value(bookId.toString()))
-      .andExpect(jsonPath("$.data.title").value("수정된 제목"))
-      .andExpect(jsonPath("$.data.author").value("수정된 저자"));
+      .andExpect(jsonPath("$.id").value(bookId.toString()))
+      .andExpect(jsonPath("$.title").value("수정된 제목"))
+      .andExpect(jsonPath("$.author").value("수정된 저자"));
   }
 
   @Test
@@ -244,10 +236,7 @@ class BookControllerTest {
     doNothing().when(bookService).deleteBook(bookId);
 
     mockMvc.perform(delete("/api/books/{bookId}", bookId))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(204))
-      .andExpect(jsonPath("$.data").doesNotExist());
+      .andExpect(status().isNoContent());
   }
 
   @Test
@@ -293,11 +282,10 @@ class BookControllerTest {
         .param("direction", "DESC")
         .param("limit", "10"))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.data.content[0].id").value(popularBookId.toString()))
-      .andExpect(jsonPath("$.data.content[0].bookId").value(bookId.toString()))
-      .andExpect(jsonPath("$.data.content[0].title").value("인기 도서"))
-      .andExpect(jsonPath("$.data.content[0].rank").value(1));
+      .andExpect(jsonPath("$.content[0].id").value(popularBookId.toString()))
+      .andExpect(jsonPath("$.content[0].bookId").value(bookId.toString()))
+      .andExpect(jsonPath("$.content[0].title").value("인기 도서"))
+      .andExpect(jsonPath("$.content[0].rank").value(1));
   }
 
   @Test
@@ -318,12 +306,10 @@ class BookControllerTest {
     mockMvc.perform(get("/api/books/info")
         .param("isbn", "9788912345678"))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(200))
-      .andExpect(jsonPath("$.data.title").value("클린 코드"))
-      .andExpect(jsonPath("$.data.author").value("로버트 마틴"))
-      .andExpect(jsonPath("$.data.isbn").value("9788912345678"))
-      .andExpect(jsonPath("$.data.thumbnailImage").value("https://image.test/book.png"));
+      .andExpect(jsonPath("$.title").value("클린 코드"))
+      .andExpect(jsonPath("$.author").value("로버트 마틴"))
+      .andExpect(jsonPath("$.isbn").value("9788912345678"))
+      .andExpect(jsonPath("$.thumbnailImage").value("https://image.test/book.png"));
   }
 
   @Test
@@ -334,9 +320,6 @@ class BookControllerTest {
     doNothing().when(bookService).hardDeleteBook(bookId);
 
     mockMvc.perform(delete("/api/books/{bookId}/hard", bookId))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.success").value(true))
-      .andExpect(jsonPath("$.status").value(204))
-      .andExpect(jsonPath("$.data").doesNotExist());
+      .andExpect(status().isNoContent());
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
@@ -22,6 +22,8 @@ import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
+import com.deokhugam.deokhugam_server.domain.book.client.NaverBookClient;
+import com.deokhugam.deokhugam_server.domain.book.client.OcrSpaceClient;
 import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.book.repository.PopularBookRepository;
@@ -54,6 +56,12 @@ class BookServiceImplTest {
 
   @Mock
   private BookMapper bookMapper;
+
+  @Mock
+  private OcrSpaceClient ocrSpaceClient;
+
+  @Mock
+  private NaverBookClient naverBookClient;
 
   @InjectMocks
   private BookServiceImpl bookService;
@@ -403,14 +411,16 @@ class BookServiceImplTest {
   }
 
   @Test
-  @DisplayName("ISBN 추출 성공 - 파일명에서 ISBN 13 추출")
+  @DisplayName("ISBN 추출 성공 - OCR 결과에서 ISBN 13 추출")
   void extractIsbn_success_isbn13() {
     MockMultipartFile image = new MockMultipartFile(
       "image",
-      "book-978-89-1234-567-8.png",
+      "book.png",
       "image/png",
       "dummy".getBytes()
     );
+
+    when(ocrSpaceClient.parseText(image)).thenReturn("ISBN 978-89-1234-567-8");
 
     String result = bookService.extractIsbn(image);
 
@@ -418,14 +428,16 @@ class BookServiceImplTest {
   }
 
   @Test
-  @DisplayName("ISBN 추출 성공 - 파일명에서 ISBN 10 추출")
+  @DisplayName("ISBN 추출 성공 - OCR 결과에서 ISBN 10 추출")
   void extractIsbn_success_isbn10() {
     MockMultipartFile image = new MockMultipartFile(
       "image",
-      "book-89-1234-567X.jpg",
+      "book.jpg",
       "image/jpeg",
       "dummy".getBytes()
     );
+
+    when(ocrSpaceClient.parseText(image)).thenReturn("ISBN 89-1234-567X");
 
     String result = bookService.extractIsbn(image);
 
@@ -467,25 +479,8 @@ class BookServiceImplTest {
   }
 
   @Test
-  @DisplayName("ISBN 추출 실패 - 파일명 없음")
-  void extractIsbn_fail_blankFilename() {
-    MockMultipartFile image = new MockMultipartFile(
-      "image",
-      "",
-      "image/png",
-      "dummy".getBytes()
-    );
-
-    DeokhugamException exception = assertThrows(DeokhugamException.class, () ->
-      bookService.extractIsbn(image)
-    );
-
-    assertEquals(ErrorCode.ISBN_EXTRACTION_FAILED, exception.getErrorCode());
-  }
-
-  @Test
-  @DisplayName("ISBN 추출 실패 - 파일명에 ISBN 없음")
-  void extractIsbn_fail_noIsbnInFilename() {
+  @DisplayName("ISBN 추출 실패 - OCR 결과에 ISBN 없음")
+  void extractIsbn_fail_noIsbnInOcrText() {
     MockMultipartFile image = new MockMultipartFile(
       "image",
       "random-book-cover.png",
@@ -493,6 +488,8 @@ class BookServiceImplTest {
       "dummy".getBytes()
     );
 
+    when(ocrSpaceClient.parseText(image)).thenReturn("no isbn text");
+
     DeokhugamException exception = assertThrows(DeokhugamException.class, () ->
       bookService.extractIsbn(image)
     );
@@ -501,21 +498,21 @@ class BookServiceImplTest {
   }
 
   @Test
-  @DisplayName("도서 정보 조회 성공 - 내부 DB 조회")
+  @DisplayName("도서 정보 조회 성공 - 네이버 API 조회")
   void getBookInfo_success() {
     String isbn = "978-89-1234-567-8";
     String normalizedIsbn = "9788912345678";
+    NaverBookDto expected = new NaverBookDto(
+      "클린 코드",
+      "로버트 마틴",
+      "설명",
+      "인사이트",
+      LocalDate.of(2024, 1, 1),
+      normalizedIsbn,
+      "https://image.test/book.png"
+    );
 
-    Book book = mock(Book.class);
-
-    when(bookRepository.findByIsbnAndIsDeletedFalse(normalizedIsbn)).thenReturn(Optional.of(book));
-    when(book.getTitle()).thenReturn("클린 코드");
-    when(book.getAuthor()).thenReturn("로버트 마틴");
-    when(book.getDescription()).thenReturn("설명");
-    when(book.getPublisher()).thenReturn("인사이트");
-    when(book.getPublishedDate()).thenReturn(LocalDate.of(2024, 1, 1));
-    when(book.getIsbn()).thenReturn(normalizedIsbn);
-    when(book.getThumbnailUrl()).thenReturn("https://image.test/book.png");
+    when(naverBookClient.searchByIsbn(normalizedIsbn)).thenReturn(expected);
 
     NaverBookDto result = bookService.getBookInfo(isbn);
 
@@ -527,12 +524,13 @@ class BookServiceImplTest {
   }
 
   @Test
-  @DisplayName("도서 정보 조회 실패 - 존재하지 않는 ISBN")
+  @DisplayName("도서 정보 조회 실패 - 네이버 API 조회 결과 없음")
   void getBookInfo_fail_notFound() {
     String isbn = "978-89-1234-567-8";
     String normalizedIsbn = "9788912345678";
 
-    when(bookRepository.findByIsbnAndIsDeletedFalse(normalizedIsbn)).thenReturn(Optional.empty());
+    when(naverBookClient.searchByIsbn(normalizedIsbn))
+      .thenThrow(new DeokhugamException(ErrorCode.BOOK_INFO_NOT_FOUND));
 
     DeokhugamException exception = assertThrows(DeokhugamException.class, () ->
       bookService.getBookInfo(isbn)

--- a/task-definition.json
+++ b/task-definition.json
@@ -68,6 +68,10 @@
         {
           "name": "NAVER_CLIENT_SECRET",
           "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:NAVER_CLIENT_SECRET::"
+        },
+        {
+          "name": "OCR_SPACE_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:OCR_SPACE_API_KEY::"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Naver-API-OCR-space-3506e443c2888116a891f355b8d01873?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- 네이버 API 및 OCR.space 연동 기반 추가
- OCR.space 이미지 텍스트 추출 클라이언트 추가
- 네이버 ISBN 도서 조회 클라이언트 추가
- /api/books/isbn/ocr, /api/books/info 엔드포인트 복구

### ♻️ 리팩토링
- OCR.space 실행 환경 설정 추가
- dev/local 예시 설정에 OCR.space API 키와 URL 추가
- ECS task definition에 OCR_SPACE_API_KEY secret 주입 추가
- 외부 ISBN 조회 계약에 맞춰 테스트 보정
- BookController 직접 응답 구조에 맞춰 JSON 검증 수정
- OCR.space와 네이버 API 클라이언트 의존성 mock 기반으로 서비스 테스트 수정

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 현재 작업 내용 중복될 수 있음 해당 내용 최신화 필요

