### PR TITLE
[BE-94] Fix: comment repository test final

### DIFF
--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImplTest.java
@@ -50,13 +50,13 @@ public class CommentRepositoryImplTest {
       .password("1234")
       .build();
     ReflectionTestUtils.setField(user, "createdAt", now);
-    ReflectionTestUtils.setField(user, "updatedAt", now); // 추가됨
+    ReflectionTestUtils.setField(user, "updatedAt", now);
     em.persist(user);
 
     // 2. 책 생성
     Book book = new Book("제목" + suffix, "저자", "ISBN-" + suffix, "출판사", "설명", "url", LocalDate.now());
     ReflectionTestUtils.setField(book, "createdAt", now);
-    ReflectionTestUtils.setField(book, "updatedAt", now); // 추가됨
+    ReflectionTestUtils.setField(book, "updatedAt", now);
     em.persist(book);
 
     // 3. 리뷰 생성
@@ -67,7 +67,7 @@ public class CommentRepositoryImplTest {
       .rating(5)
       .build();
     ReflectionTestUtils.setField(review, "createdAt", now);
-    ReflectionTestUtils.setField(review, "updatedAt", now); // 추가됨
+    ReflectionTestUtils.setField(review, "updatedAt", now);
     em.persist(review);
     em.flush();
 
@@ -78,7 +78,7 @@ public class CommentRepositoryImplTest {
       .content("옛날댓글")
       .build();
     ReflectionTestUtils.setField(commentOld, "createdAt", now);
-    ReflectionTestUtils.setField(commentOld, "updatedAt", now); // 추가됨
+    ReflectionTestUtils.setField(commentOld, "updatedAt", now);
     em.persist(commentOld);
 
     // 5. 최신 댓글 생성
@@ -94,7 +94,7 @@ public class CommentRepositoryImplTest {
 
     em.flush();
 
-    // 6. 시간 업데이트 (Native Query)
+    // 6. 시간 업데이트
     em.createNativeQuery("UPDATE comments SET created_at = ?1 WHERE content = ?2")
       .setParameter(1, FIXED_OLD)
       .setParameter(2, "옛날댓글")
@@ -114,7 +114,7 @@ public class CommentRepositoryImplTest {
     // given
     CommentSearchRequest request = new CommentSearchRequest();
     request.setReviewId(review.getId());
-    request.setAfter(FIXED_NOW); // 최신댓글 시간 기준
+    request.setAfter(FIXED_NOW);
     request.setCursor(commentNewId.toString());
     request.setDirection("DESC");
     request.setLimit(10);
@@ -157,7 +157,6 @@ public class CommentRepositoryImplTest {
 
     // then
     assertThat(result).hasSize(2);
-    // 💡 "민주" 대신 user.getNickname()을 사용하세요!
     assertThat(result.stream().anyMatch(c -> c.userNickname().equals(user.getNickname()))).isTrue();
   }
 

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/comment/repository/CommentRepositoryImplTest.java
@@ -40,28 +40,61 @@ public class CommentRepositoryImplTest {
 
   @BeforeEach
   void setUp() {
-    // 1. 유저, 책, 리뷰 생성
-    user = User.builder().email("test@test.com").nickname("민주").password("1234").build();
+    String suffix = UUID.randomUUID().toString().substring(0, 8);
+    LocalDateTime now = LocalDateTime.now();
+
+    // 1. 유저 생성
+    user = User.builder()
+      .email("test" + suffix + "@test.com")
+      .nickname("민주" + suffix)
+      .password("1234")
+      .build();
+    ReflectionTestUtils.setField(user, "createdAt", now);
+    ReflectionTestUtils.setField(user, "updatedAt", now); // 추가됨
     em.persist(user);
 
-    Book book = new Book("제목", "저자", "ISBN", "출판사", "설명", "url", LocalDate.now());
+    // 2. 책 생성
+    Book book = new Book("제목" + suffix, "저자", "ISBN-" + suffix, "출판사", "설명", "url", LocalDate.now());
+    ReflectionTestUtils.setField(book, "createdAt", now);
+    ReflectionTestUtils.setField(book, "updatedAt", now); // 추가됨
     em.persist(book);
 
-    review = Review.builder().user(user).book(book).content("리뷰").rating(5).build();
+    // 3. 리뷰 생성
+    review = Review.builder()
+      .user(user)
+      .book(book)
+      .content("리뷰 내용")
+      .rating(5)
+      .build();
+    ReflectionTestUtils.setField(review, "createdAt", now);
+    ReflectionTestUtils.setField(review, "updatedAt", now); // 추가됨
     em.persist(review);
     em.flush();
 
-    // 2. 옛날 댓글 생성
-    Comment commentOld = Comment.builder().review(review).userId(user.getId()).content("옛날댓글").build();
+    // 4. 옛날 댓글 생성
+    Comment commentOld = Comment.builder()
+      .review(review)
+      .userId(user.getId())
+      .content("옛날댓글")
+      .build();
+    ReflectionTestUtils.setField(commentOld, "createdAt", now);
+    ReflectionTestUtils.setField(commentOld, "updatedAt", now); // 추가됨
     em.persist(commentOld);
 
-    // 3. 최신 댓글 생성
-    Comment commentNew = Comment.builder().review(review).userId(user.getId()).content("최신댓글").build();
+    // 5. 최신 댓글 생성
+    Comment commentNew = Comment.builder()
+      .review(review)
+      .userId(user.getId())
+      .content("최신댓글")
+      .build();
+    ReflectionTestUtils.setField(commentNew, "createdAt", now);
+    ReflectionTestUtils.setField(commentNew, "updatedAt", now); // 추가됨
     em.persist(commentNew);
     commentNewId = commentNew.getId();
 
     em.flush();
 
+    // 6. 시간 업데이트 (Native Query)
     em.createNativeQuery("UPDATE comments SET created_at = ?1 WHERE content = ?2")
       .setParameter(1, FIXED_OLD)
       .setParameter(2, "옛날댓글")
@@ -124,7 +157,8 @@ public class CommentRepositoryImplTest {
 
     // then
     assertThat(result).hasSize(2);
-    assertThat(result.stream().anyMatch(c -> c.userNickname().equals("민주"))).isTrue();
+    // 💡 "민주" 대신 user.getNickname()을 사용하세요!
+    assertThat(result.stream().anyMatch(c -> c.userNickname().equals(user.getNickname()))).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Comment-repository-test-3506e443c28880a89eb6cedc9856f80e?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정

* JPA Auditing 필드 NULL 입력 문제 해결
    * 원인: @DataJpaTest 환경에서 JpaAuditing 설정이 로드되지 않아 BaseEntity의 createdAt, updatedAt 필드에 null이 입력되어 DB 제약 조건(NOT NULL)을 위반함.
    * 해결: ReflectionTestUtils를 사용하여 테스트 데이터 생성 시 해당 필드에 LocalDateTime.now() 값을 수동으로 주입하여 해결함.

* 테스트 데이터 간 Unique 제약 조건 충돌 해결
    * 원인: ISBN, Email, Nickname 등 유니크 제약 조건이 설정된 필드에 고정된 값을 사용함에 따라, 타 도메인 테스트 데이터와 중복이 발생하여 테스트가 실패함.
    * 해결: UUID를 활용한 랜덤 접미사(suffix)를 도입하여 각 테스트 케이스가 독립적인 데이터를 가지도록 보장함.

* 테스트 검증 로직의 하드코딩 제거
    * 원인: 데이터 유니크 처리를 위해 닉네임에 랜덤 문자열이 추가되면서, 기존의 하드코딩된 기대값과 실제 저장된 값이 일치하지 않는 문제 발생.
    * 해결: 실제 저장된 객체의 필드 값(user.getNickname())을 참조하여 동적으로 검증하도록 수정함.

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경