### PR TITLE
[BE-31, BE-96] Test: global notification 단위 테스트

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
@@ -66,16 +66,14 @@ public class PopularReviewService {
     for (int i = 0; i < rankings.size(); i++) {
       rankings.get(i).assignRankOrder(i + 1);
     }
-    if (!existingRankings.isEmpty()) {
-    popularReviewRepository.deleteAllInBatch(existingRankings);
-}
-    popularReviewRepository.saveAll(rankings);
 
     List<PopularReview> existingRankings =
         popularReviewRepository.findAllByPeriodTypeAndCalculatedDate(periodType, endDate);
     if (!existingRankings.isEmpty()) {
       popularReviewRepository.deleteAllInBatch(existingRankings);
     }
+
+    popularReviewRepository.saveAll(rankings);
 
     rankings.stream()
         .filter(r -> r.getRankOrder() <= 10)

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/batch/NotificationCleanupBatchTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/batch/NotificationCleanupBatchTest.java
@@ -1,0 +1,29 @@
+package com.deokhugam.deokhugam_server.domain.notification.batch;
+
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCleanupBatchTest {
+
+  @InjectMocks
+  private NotificationCleanupBatch batch;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Test
+  @DisplayName("성공: 배치 실행 시 만료 알림 삭제 서비스를 호출한다")
+  void execute() {
+    batch.execute();
+
+    verify(notificationService).deleteExpiredNotifications();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListenerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListenerTest.java
@@ -1,0 +1,148 @@
+package com.deokhugam.deokhugam_server.domain.notification.event;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.domain.comment.event.CommentCreatedEvent;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.domain.notification.service.NotificationService;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewLikedEvent;
+import com.deokhugam.deokhugam_server.domain.review.event.ReviewRankedEvent;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+  @InjectMocks
+  private NotificationEventListener listener;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Test
+  @DisplayName("성공: 다른 사용자가 댓글을 달면 리뷰 작성자에게 댓글 알림을 생성한다")
+  void handleCommentCreated_CreateNotification() {
+    UUID reviewId = UUID.randomUUID();
+    UUID reviewOwnerId = UUID.randomUUID();
+    UUID commentAuthorId = UUID.randomUUID();
+    Review review = mockReview(reviewOwnerId);
+
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+
+    listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), commentAuthorId));
+
+    verify(notificationService).createNotification(
+      eq(reviewId),
+      eq(reviewOwnerId),
+      eq(NotificationType.REVIEW_COMMENTED),
+      eq("회원님의 리뷰에 댓글이 달렸습니다.")
+    );
+  }
+
+  @Test
+  @DisplayName("성공: 자기 리뷰에 직접 댓글을 달면 알림을 생성하지 않는다")
+  void handleCommentCreated_SkipSelfComment() {
+    UUID reviewId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
+    Review review = mockReview(ownerId);
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
+
+    listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), ownerId));
+
+    verify(notificationService, never()).createNotification(
+      eq(reviewId),
+      eq(ownerId),
+      eq(NotificationType.REVIEW_COMMENTED),
+      eq("회원님의 리뷰에 댓글이 달렸습니다.")
+    );
+  }
+
+  @Test
+  @DisplayName("실패: 댓글 이벤트의 리뷰가 없으면 예외가 발생한다")
+  void handleCommentCreated_ReviewNotFound() {
+    UUID reviewId = UUID.randomUUID();
+    given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() ->
+      listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), UUID.randomUUID())))
+      .isInstanceOf(DeokhugamException.class)
+      .hasMessageContaining(ErrorCode.REVIEW_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("성공: 다른 사용자가 좋아요를 누르면 리뷰 작성자에게 좋아요 알림을 생성한다")
+  void handleReviewLiked_CreateNotification() {
+    UUID reviewId = UUID.randomUUID();
+    UUID likerId = UUID.randomUUID();
+    UUID targetUserId = UUID.randomUUID();
+
+    listener.handleReviewLiked(new ReviewLikedEvent(reviewId, likerId, targetUserId, "리뷰 내용"));
+
+    verify(notificationService).createNotification(
+      eq(reviewId),
+      eq(targetUserId),
+      eq(NotificationType.REVIEW_LIKED),
+      eq("회원님의 리뷰에 좋아요가 달렸습니다.")
+    );
+  }
+
+  @Test
+  @DisplayName("성공: 자기 리뷰에 직접 좋아요를 누르면 알림을 생성하지 않는다")
+  void handleReviewLiked_SkipSelfLike() {
+    UUID userId = UUID.randomUUID();
+
+    listener.handleReviewLiked(new ReviewLikedEvent(UUID.randomUUID(), userId, userId, "리뷰 내용"));
+
+    verify(notificationService, never()).createNotification(
+      org.mockito.ArgumentMatchers.any(),
+      org.mockito.ArgumentMatchers.any(),
+      org.mockito.ArgumentMatchers.any(),
+      org.mockito.ArgumentMatchers.any()
+    );
+  }
+
+  @Test
+  @DisplayName("성공: 인기 리뷰 진입 이벤트는 순위 알림을 생성한다")
+  void handleReviewRanked_CreateNotification() {
+    UUID reviewId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    listener.handleReviewRanked(new ReviewRankedEvent(reviewId, userId, Period.DAILY, 3, "리뷰 내용"));
+
+    verify(notificationService).createNotification(
+      eq(reviewId),
+      eq(userId),
+      eq(NotificationType.REVIEW_RANKED),
+      eq("회원님의 리뷰가 DAILY 기간 인기 리뷰 3위에 선정되었습니다.")
+    );
+  }
+
+  private Review mockReview(UUID userId) {
+    User user = mock(User.class);
+    given(user.getId()).willReturn(userId);
+
+    Review review = mock(Review.class);
+    given(review.getUser()).willReturn(user);
+    return review;
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/service/NotificationServiceImplTest.java
@@ -3,6 +3,8 @@ package com.deokhugam.deokhugam_server.domain.notification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.notification.dto.response.NotificationDto;
@@ -44,6 +46,39 @@ class NotificationServiceImplTest {
     private UserRepository userRepository;
 
     @Test
+    @DisplayName("성공: 알림을 생성하고 저장된 엔티티를 DTO로 반환한다")
+    void createNotification_Success() {
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Notification savedNotification = new Notification(reviewId, userId, NotificationType.REVIEW_LIKED, "좋아요 알림");
+        UUID notificationId = UUID.randomUUID();
+        ReflectionTestUtils.setField(savedNotification, "id", notificationId);
+        NotificationDto expected = new NotificationDto(
+            notificationId,
+            userId,
+            reviewId,
+            "리뷰 내용",
+            "좋아요 알림",
+            false,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+
+        given(notificationRepository.save(org.mockito.ArgumentMatchers.any(Notification.class)))
+            .willReturn(savedNotification);
+        given(notificationMapper.toDto(savedNotification)).willReturn(expected);
+
+        NotificationDto result = notificationService.createNotification(
+            reviewId,
+            userId,
+            NotificationType.REVIEW_LIKED,
+            "좋아요 알림"
+        );
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
     @DisplayName("성공: confirmed 값에 따라 알림 읽음 상태를 업데이트한다")
     void readNotification_Success() {
         UUID notificationId = UUID.randomUUID();
@@ -68,6 +103,20 @@ class NotificationServiceImplTest {
         notificationService.readNotification(notificationId, userId, new NotificationUpdateRequest(false));
 
         assertThat(notification.isRead()).isFalse();
+    }
+
+    @Test
+    @DisplayName("실패: 알림 읽음 상태 업데이트 시 알림이 없으면 예외가 발생한다")
+    void readNotification_Fail_WhenNotificationNotFound() {
+        UUID notificationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(notificationRepository.findByIdAndIsDeletedFalse(notificationId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            notificationService.readNotification(notificationId, userId, new NotificationUpdateRequest(true)))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -136,6 +185,23 @@ class NotificationServiceImplTest {
     }
 
     @Test
+    @DisplayName("성공: 모든 미확인 알림을 읽음 처리한다")
+    void readAllNotifications_Success() {
+        UUID userId = UUID.randomUUID();
+        Notification first = new Notification(UUID.randomUUID(), userId, NotificationType.REVIEW_COMMENTED, "첫 번째");
+        Notification second = new Notification(UUID.randomUUID(), userId, NotificationType.REVIEW_LIKED, "두 번째");
+
+        given(userRepository.findByIdAndIsDeletedFalse(userId))
+            .willReturn(Optional.of(org.mockito.Mockito.mock(User.class)));
+        given(notificationRepository.findUnreadByUserId(userId)).willReturn(List.of(first, second));
+
+        notificationService.readAllNotifications(userId);
+
+        assertThat(first.isRead()).isTrue();
+        assertThat(second.isRead()).isTrue();
+    }
+
+    @Test
     @DisplayName("실패: 모든 알림 읽음 처리 시 사용자가 없으면 예외가 발생한다")
     void readAllNotifications_Fail_WhenUserNotFound() {
         UUID userId = UUID.randomUUID();
@@ -144,5 +210,22 @@ class NotificationServiceImplTest {
         assertThatThrownBy(() -> notificationService.readAllNotifications(userId))
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+
+        verifyNoInteractions(notificationRepository);
+    }
+
+    @Test
+    @DisplayName("성공: 만료된 읽음 알림을 논리 삭제한다")
+    void deleteExpiredNotifications_Success() {
+        Notification first = new Notification(UUID.randomUUID(), UUID.randomUUID(), NotificationType.REVIEW_COMMENTED, "첫 번째");
+        Notification second = new Notification(UUID.randomUUID(), UUID.randomUUID(), NotificationType.REVIEW_RANKED, "두 번째");
+        given(notificationRepository.findExpiredReadNotifications(org.mockito.ArgumentMatchers.any(LocalDateTime.class)))
+            .willReturn(List.of(first, second));
+
+        notificationService.deleteExpiredNotifications();
+
+        assertThat(first.isDeleted()).isTrue();
+        assertThat(second.isDeleted()).isTrue();
+        verify(notificationRepository).findExpiredReadNotifications(org.mockito.ArgumentMatchers.any(LocalDateTime.class));
     }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewRankedEventTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewRankedEventTest.java
@@ -56,7 +56,7 @@ public class ReviewRankedEventTest {
         .user(User.builder().id(UUID.randomUUID()).build())
         .content("인기리뷰")
         .build();
-    given(reviewRepository.getReferenceById(reviewId)).willReturn(mockReview);
+    given(reviewRepository.findAllById(any())).willReturn(List.of(mockReview));
 
     // [When]
     popularReviewService.calculateAndSaveReviewRanks(Period.DAILY);

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewServiceTest.java
@@ -16,7 +16,9 @@ import com.deokhugam.deokhugam_server.domain.user.entity.User;
 import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +40,7 @@ class PopularReviewServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private ReviewMapper reviewMapper;
   @Mock private ApplicationEventPublisher eventPublisher;
+  private Map<UUID, Review> reviewMap;
 
   @BeforeEach
   void setUp() {
@@ -46,6 +49,7 @@ class PopularReviewServiceTest {
         reviewRepository, popularReviewRepository, bookRepository,
         userRepository, reviewMapper, eventPublisher
     );
+    reviewMap = new HashMap<>();
   }
 
   @AfterEach
@@ -69,6 +73,7 @@ class PopularReviewServiceTest {
 
     setupMockReview(reviewId1, "높은 점수 리뷰");
     setupMockReview(reviewId2, "낮은 점수 리뷰");
+    when(reviewRepository.findAllById(any())).thenReturn(List.copyOf(reviewMap.values()));
 
     when(popularReviewRepository.findAllByPeriodTypeAndCalculatedDate(any(), any()))
         .thenReturn(Collections.emptyList());
@@ -92,10 +97,10 @@ class PopularReviewServiceTest {
     Review mockReview = mock(Review.class);
     User mockUser = mock(User.class);
 
-    when(reviewRepository.getReferenceById(reviewId)).thenReturn(mockReview);
     when(mockReview.getId()).thenReturn(reviewId);
     when(mockReview.getUser()).thenReturn(mockUser);
     when(mockReview.getContent()).thenReturn(content);
     when(mockUser.getId()).thenReturn(UUID.randomUUID());
+    reviewMap.put(reviewId, mockReview);
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/filter/JwtAuthenticationFilterTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,69 @@
+package com.deokhugam.deokhugam_server.global.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.FilterChain;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class JwtAuthenticationFilterTest {
+
+  private static final String USER_ID_HEADER = "Deokhugam-Request-User-ID";
+
+  private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter();
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("성공: 유효한 사용자 ID 헤더가 있으면 SecurityContext 인증 정보를 설정한다")
+  void doFilter_SetsAuthentication() throws ServletException, IOException {
+    UUID userId = UUID.randomUUID();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(USER_ID_HEADER, userId.toString());
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicReference<Authentication> authenticationInChain = new AtomicReference<>();
+    FilterChain chain = (req, res) ->
+      authenticationInChain.set(SecurityContextHolder.getContext().getAuthentication());
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(authenticationInChain.get()).isNotNull();
+    assertThat(authenticationInChain.get().getPrincipal()).isEqualTo(userId);
+  }
+
+  @Test
+  @DisplayName("성공: 사용자 ID 헤더가 없으면 인증 정보를 설정하지 않는다")
+  void doFilter_NoHeader() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: 잘못된 UUID 헤더는 인증 없이 통과한다")
+  void doFilter_InvalidHeader() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(USER_ID_HEADER, "invalid-uuid");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/filter/MdcLoggingFilterTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/filter/MdcLoggingFilterTest.java
@@ -1,0 +1,56 @@
+package com.deokhugam.deokhugam_server.global.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.FilterChain;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class MdcLoggingFilterTest {
+
+  private final MdcLoggingFilter filter = new MdcLoggingFilter();
+
+  @Test
+  @DisplayName("성공: 요청 ID와 X-Forwarded-For의 첫 번째 IP를 MDC와 응답 헤더에 설정한다")
+  void doFilter_SetsMdcAndResponseHeader() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Forwarded-For", "203.0.113.10, 10.0.0.1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicReference<String> requestIdInChain = new AtomicReference<>();
+    AtomicReference<String> clientIpInChain = new AtomicReference<>();
+
+    FilterChain chain = (req, res) -> {
+      requestIdInChain.set(MDC.get("requestId"));
+      clientIpInChain.set(MDC.get("clientIp"));
+    };
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(requestIdInChain.get()).hasSize(12);
+    assertThat(clientIpInChain.get()).isEqualTo("203.0.113.10");
+    assertThat(response.getHeader("X-Request-Id")).isEqualTo(requestIdInChain.get());
+    assertThat(MDC.get("requestId")).isNull();
+    assertThat(MDC.get("clientIp")).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: X-Forwarded-For가 없으면 remoteAddr를 clientIp로 사용한다")
+  void doFilter_UsesRemoteAddr() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("198.51.100.20");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicReference<String> clientIpInChain = new AtomicReference<>();
+
+    FilterChain chain = (req, res) -> clientIpInChain.set(MDC.get("clientIp"));
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(clientIpInChain.get()).isEqualTo("198.51.100.20");
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/interceptor/RequestUserIdInterceptorTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/interceptor/RequestUserIdInterceptorTest.java
@@ -1,0 +1,50 @@
+package com.deokhugam.deokhugam_server.global.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestUserIdInterceptorTest {
+
+  private final RequestUserIdInterceptor interceptor = new RequestUserIdInterceptor();
+
+  @Test
+  @DisplayName("성공: 유효한 사용자 ID 헤더를 request attribute에 UUID로 저장한다")
+  void preHandle_ValidUserIdHeader() {
+    UUID userId = UUID.randomUUID();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(RequestUserIdInterceptor.USER_ID_HEADER, userId.toString());
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(request.getAttribute(RequestUserIdInterceptor.USER_ID_ATTRIBUTE)).isEqualTo(userId);
+  }
+
+  @Test
+  @DisplayName("성공: 헤더가 없으면 attribute를 설정하지 않고 통과한다")
+  void preHandle_NoHeader() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(request.getAttribute(RequestUserIdInterceptor.USER_ID_ATTRIBUTE)).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: 잘못된 UUID 헤더는 attribute를 설정하지 않고 통과한다")
+  void preHandle_InvalidHeader() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(RequestUserIdInterceptor.USER_ID_HEADER, "invalid-uuid");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(request.getAttribute(RequestUserIdInterceptor.USER_ID_ATTRIBUTE)).isNull();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/CursorPageUtilTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/CursorPageUtilTest.java
@@ -1,0 +1,64 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CursorPageUtilTest {
+
+  @Test
+  @DisplayName("성공: limit보다 결과가 많으면 다음 커서와 after를 반환한다")
+  void toResponse_HasNext() {
+    LocalDateTime firstTime = LocalDateTime.of(2026, 4, 28, 10, 0);
+    LocalDateTime secondTime = LocalDateTime.of(2026, 4, 28, 9, 0);
+    List<TestItem> items = List.of(
+      new TestItem("first", firstTime),
+      new TestItem("second", secondTime),
+      new TestItem("third", LocalDateTime.of(2026, 4, 28, 8, 0))
+    );
+
+    CursorPageResponse<String> response = CursorPageUtil.toResponse(
+      items,
+      2,
+      3,
+      TestItem::id,
+      TestItem::id,
+      TestItem::createdAt
+    );
+
+    assertThat(response.content()).containsExactly("first", "second");
+    assertThat(response.nextCursor()).isEqualTo("second");
+    assertThat(response.nextAfter()).isEqualTo(secondTime);
+    assertThat(response.size()).isEqualTo(2);
+    assertThat(response.totalElements()).isEqualTo(3);
+    assertThat(response.hasNext()).isTrue();
+  }
+
+  @Test
+  @DisplayName("성공: 다음 페이지가 없으면 커서와 after를 null로 반환한다")
+  void toResponse_NoNext() {
+    LocalDateTime createdAt = LocalDateTime.of(2026, 4, 28, 10, 0);
+    List<TestItem> items = List.of(new TestItem("only", createdAt));
+
+    CursorPageResponse<String> response = CursorPageUtil.toResponse(
+      items,
+      20,
+      1,
+      TestItem::id,
+      TestItem::id,
+      TestItem::createdAt
+    );
+
+    assertThat(response.content()).containsExactly("only");
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.nextAfter()).isNull();
+    assertThat(response.hasNext()).isFalse();
+  }
+
+  private record TestItem(String id, LocalDateTime createdAt) {
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/DateTimeUtilsTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/DateTimeUtilsTest.java
@@ -1,0 +1,51 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DateTimeUtilsTest {
+
+  @Test
+  @DisplayName("성공: null 또는 blank는 null을 반환한다")
+  void parseLocalDateTime_NullOrBlank() {
+    assertThat(DateTimeUtils.parseLocalDateTime(null)).isNull();
+    assertThat(DateTimeUtils.parseLocalDateTime(" ")).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: ISO 로컬 날짜시간을 파싱한다")
+  void parseLocalDateTime_IsoLocalDateTime() {
+    assertThat(DateTimeUtils.parseLocalDateTime("2026-04-28T11:30:00"))
+      .isEqualTo(LocalDateTime.of(2026, 4, 28, 11, 30));
+  }
+
+  @Test
+  @DisplayName("성공: 공백 구분 날짜시간을 ISO 형식으로 보정해 파싱한다")
+  void parseLocalDateTime_SpaceSeparatedDateTime() {
+    assertThat(DateTimeUtils.parseLocalDateTime("2026-04-28 11:30:00"))
+      .isEqualTo(LocalDateTime.of(2026, 4, 28, 11, 30));
+  }
+
+  @Test
+  @DisplayName("성공: Zulu 시간은 KST LocalDateTime으로 변환한다")
+  void parseLocalDateTime_ZonedUtc() {
+    assertThat(DateTimeUtils.parseLocalDateTime("2026-04-28T02:30:00Z"))
+      .isEqualTo(LocalDateTime.of(2026, 4, 28, 11, 30));
+  }
+
+  @Test
+  @DisplayName("성공: 날짜만 유효하면 해당 날짜의 시작 시간으로 변환한다")
+  void parseLocalDateTime_DateFallback() {
+    assertThat(DateTimeUtils.parseLocalDateTime("2026-04-28-invalid"))
+      .isEqualTo(LocalDateTime.of(2026, 4, 28, 0, 0));
+  }
+
+  @Test
+  @DisplayName("실패: 파싱할 수 없는 값은 null을 반환한다")
+  void parseLocalDateTime_Invalid() {
+    assertThat(DateTimeUtils.parseLocalDateTime("invalid")).isNull();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/JwtProviderTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/JwtProviderTest.java
@@ -1,0 +1,51 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Base64;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class JwtProviderTest {
+
+  private JwtProvider jwtProvider;
+
+  @BeforeEach
+  void setUp() {
+    jwtProvider = new JwtProvider();
+    String secret = Base64.getEncoder()
+      .encodeToString("12345678901234567890123456789012".getBytes());
+    ReflectionTestUtils.setField(jwtProvider, "secret", secret);
+    ReflectionTestUtils.setField(jwtProvider, "expiration", 60_000L);
+  }
+
+  @Test
+  @DisplayName("성공: 사용자 ID로 JWT를 생성하고 다시 사용자 ID를 추출한다")
+  void generateTokenAndGetUserId() {
+    UUID userId = UUID.randomUUID();
+
+    String token = jwtProvider.generateToken(userId);
+
+    assertThat(jwtProvider.validateToken(token)).isTrue();
+    assertThat(jwtProvider.getUserIdFromToken(token)).isEqualTo(userId);
+  }
+
+  @Test
+  @DisplayName("실패: 잘못된 JWT는 검증에 실패한다")
+  void validateToken_InvalidToken() {
+    assertThat(jwtProvider.validateToken("invalid.token.value")).isFalse();
+  }
+
+  @Test
+  @DisplayName("실패: 만료된 JWT는 검증에 실패한다")
+  void validateToken_ExpiredToken() {
+    ReflectionTestUtils.setField(jwtProvider, "expiration", -1L);
+
+    String token = jwtProvider.generateToken(UUID.randomUUID());
+
+    assertThat(jwtProvider.validateToken(token)).isFalse();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/PeriodUtilTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/PeriodUtilTest.java
@@ -1,0 +1,34 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PeriodUtilTest {
+
+  @Test
+  @DisplayName("성공: 배치 기준 시작 날짜를 기간별로 계산한다")
+  void getStartDate_ByPeriod() {
+    LocalDate endDate = LocalDate.of(2026, 4, 28);
+
+    assertThat(PeriodUtil.getStartDate(Period.DAILY, endDate)).isEqualTo(endDate);
+    assertThat(PeriodUtil.getStartDate(Period.WEEKLY, endDate)).isEqualTo(LocalDate.of(2026, 4, 21));
+    assertThat(PeriodUtil.getStartDate(Period.MONTHLY, endDate)).isEqualTo(LocalDate.of(2026, 3, 28));
+    assertThat(PeriodUtil.getStartDate(Period.ALL_TIME, endDate)).isEqualTo(LocalDate.of(2000, 1, 1));
+  }
+
+  @Test
+  @DisplayName("성공: 조회 기준 시작 시간을 기간별로 계산한다")
+  void calculateStartTime_ByPeriod() {
+    LocalDateTime before = LocalDateTime.now();
+
+    assertThat(PeriodUtil.calculateStartTime(Period.DAILY)).isBeforeOrEqualTo(before);
+    assertThat(PeriodUtil.calculateStartTime(Period.WEEKLY)).isBeforeOrEqualTo(before.minusDays(6));
+    assertThat(PeriodUtil.calculateStartTime(Period.MONTHLY)).isBeforeOrEqualTo(before.minusDays(27));
+    assertThat(PeriodUtil.calculateStartTime(Period.ALL_TIME)).isEqualTo(LocalDateTime.of(2020, 1, 1, 0, 0));
+  }
+}


### PR DESCRIPTION
## 🔗 Notion Task 링크
- https://www.notion.so/Notification-JUnit5-Mockito-3506e443c288818e990ee82df917610c?source=copy_link
- https://www.notion.so/global-JUnit5-Mockito-3506e443c2888043ab5bec920dbe61dc?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- PopularReviewService에서 존재하지 않는 existingRankings 변수를 먼저 참조하던 컴파일 오류 수정
- 인기 리뷰 랭킹 저장 시 기존 랭킹 조회/삭제 순서를 새 랭킹 생성 이후 정리
- 인기 리뷰 관련 테스트에서 현재 서비스 구현에 맞게 reviewRepository.findAllById(...) 기반으로 mock 설정 보정

### ✨ 기능 추가 / 구현
- 알림 배치 정리 로직 테스트를 추가
- 알림 이벤트 리스너 테스트를 추가
- 공통 필터, 인터셉터, 유틸 클래스에 대한 단위 테스트를 추가
- 사용자 ID 헤더 기반 인증 필터 동작 테스트를 추가

### ♻️ 리팩토링
- 인기 리뷰 랭킹 갱신 흐름을 랭킹 계산 → 기존 랭킹 삭제 → 신규 랭킹 저장 → 이벤트 발행 순서로 명확히 정리
- 테스트 mock 대상이 실제 구현 흐름과 맞도록 정리

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 전체 테스트는 현재 BookControllerTest의 기존 실패로 인해 통과하지 못함.

