### PR TITLE
[BE-121]fix: BookControllerTest 응답 구조 수정 및 BookService 테스트 보강

### DIFF
--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/controller/BookControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/controller/BookControllerTest.java
@@ -85,7 +85,11 @@ class BookControllerTest {
       .andExpect(jsonPath("$.id").value(bookId.toString()))
       .andExpect(jsonPath("$.title").value("클린 코드"))
       .andExpect(jsonPath("$.author").value("로버트 마틴"))
-      .andExpect(jsonPath("$.isbn").value("9788912345678"));
+      .andExpect(jsonPath("$.description").value("설명"))
+      .andExpect(jsonPath("$.publisher").value("인사이트"))
+      .andExpect(jsonPath("$.publishedDate").value("2024-01-01"))
+      .andExpect(jsonPath("$.isbn").value("9788912345678"))
+      .andExpect(jsonPath("$.thumbnailImage").value("https://image.test/thumbnail.png"));
   }
 
   @Test
@@ -128,6 +132,11 @@ class BookControllerTest {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.content[0].id").value(bookId.toString()))
       .andExpect(jsonPath("$.content[0].title").value("책 제목"))
+      .andExpect(jsonPath("$.content[0].author").value("저자"))
+      .andExpect(jsonPath("$.content[0].isbn").value("1234567890"))
+      .andExpect(jsonPath("$.content[0].reviewCount").value(1))
+      .andExpect(jsonPath("$.content[0].rating").value(4.0))
+      .andExpect(jsonPath("$.size").value(1))
       .andExpect(jsonPath("$.totalElements").value(1))
       .andExpect(jsonPath("$.hasNext").value(false));
   }
@@ -137,7 +146,7 @@ class BookControllerTest {
   void extractIsbn_success() throws Exception {
     MockMultipartFile image = new MockMultipartFile(
       "image",
-      "book-978-89-1234-567-8.png",
+      "book.png",
       "image/png",
       "dummy-image".getBytes()
     );
@@ -148,6 +157,33 @@ class BookControllerTest {
         .file(image))
       .andExpect(status().isOk())
       .andExpect(content().string("9788912345678"));
+  }
+
+  @Test
+  @DisplayName("도서 정보 조회 성공")
+  void getBookInfo_success() throws Exception {
+    NaverBookDto response = new NaverBookDto(
+      "클린 코드",
+      "로버트 마틴",
+      "설명",
+      "인사이트",
+      LocalDate.of(2024, 1, 1),
+      "9788912345678",
+      "https://image.test/book.png"
+    );
+
+    when(bookService.getBookInfo("9788912345678")).thenReturn(response);
+
+    mockMvc.perform(get("/api/books/info")
+        .param("isbn", "9788912345678"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.title").value("클린 코드"))
+      .andExpect(jsonPath("$.author").value("로버트 마틴"))
+      .andExpect(jsonPath("$.description").value("설명"))
+      .andExpect(jsonPath("$.publisher").value("인사이트"))
+      .andExpect(jsonPath("$.publishedDate").value("2024-01-01"))
+      .andExpect(jsonPath("$.isbn").value("9788912345678"))
+      .andExpect(jsonPath("$.thumbnailImage").value("https://image.test/book.png"));
   }
 
   @Test
@@ -177,6 +213,8 @@ class BookControllerTest {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.id").value(bookId.toString()))
       .andExpect(jsonPath("$.title").value("책 제목"))
+      .andExpect(jsonPath("$.author").value("저자"))
+      .andExpect(jsonPath("$.isbn").value("1234567890"))
       .andExpect(jsonPath("$.reviewCount").value(3))
       .andExpect(jsonPath("$.rating").value(4.5));
   }
@@ -225,7 +263,11 @@ class BookControllerTest {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.id").value(bookId.toString()))
       .andExpect(jsonPath("$.title").value("수정된 제목"))
-      .andExpect(jsonPath("$.author").value("수정된 저자"));
+      .andExpect(jsonPath("$.author").value("수정된 저자"))
+      .andExpect(jsonPath("$.description").value("수정된 설명"))
+      .andExpect(jsonPath("$.publisher").value("수정된 출판사"))
+      .andExpect(jsonPath("$.publishedDate").value("2025-01-01"))
+      .andExpect(jsonPath("$.isbn").value("1234567890"));
   }
 
   @Test
@@ -236,6 +278,17 @@ class BookControllerTest {
     doNothing().when(bookService).deleteBook(bookId);
 
     mockMvc.perform(delete("/api/books/{bookId}", bookId))
+      .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("도서 물리 삭제 성공")
+  void hardDeleteBook_success() throws Exception {
+    UUID bookId = UUID.randomUUID();
+
+    doNothing().when(bookService).hardDeleteBook(bookId);
+
+    mockMvc.perform(delete("/api/books/{bookId}/hard", bookId))
       .andExpect(status().isNoContent());
   }
 
@@ -285,41 +338,10 @@ class BookControllerTest {
       .andExpect(jsonPath("$.content[0].id").value(popularBookId.toString()))
       .andExpect(jsonPath("$.content[0].bookId").value(bookId.toString()))
       .andExpect(jsonPath("$.content[0].title").value("인기 도서"))
-      .andExpect(jsonPath("$.content[0].rank").value(1));
-  }
-
-  @Test
-  @DisplayName("도서 정보 조회 성공")
-  void getBookInfo_success() throws Exception {
-    NaverBookDto response = new NaverBookDto(
-      "클린 코드",
-      "로버트 마틴",
-      "설명",
-      "인사이트",
-      LocalDate.of(2024, 1, 1),
-      "9788912345678",
-      "https://image.test/book.png"
-    );
-
-    when(bookService.getBookInfo("9788912345678")).thenReturn(response);
-
-    mockMvc.perform(get("/api/books/info")
-        .param("isbn", "9788912345678"))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.title").value("클린 코드"))
-      .andExpect(jsonPath("$.author").value("로버트 마틴"))
-      .andExpect(jsonPath("$.isbn").value("9788912345678"))
-      .andExpect(jsonPath("$.thumbnailImage").value("https://image.test/book.png"));
-  }
-
-  @Test
-  @DisplayName("도서 물리 삭제 성공")
-  void hardDeleteBook_success() throws Exception {
-    UUID bookId = UUID.randomUUID();
-
-    doNothing().when(bookService).hardDeleteBook(bookId);
-
-    mockMvc.perform(delete("/api/books/{bookId}/hard", bookId))
-      .andExpect(status().isNoContent());
+      .andExpect(jsonPath("$.content[0].author").value("인기 저자"))
+      .andExpect(jsonPath("$.content[0].rank").value(1))
+      .andExpect(jsonPath("$.content[0].score").value(9.5))
+      .andExpect(jsonPath("$.content[0].reviewCount").value(20))
+      .andExpect(jsonPath("$.content[0].rating").value(4.8));
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.deokhugam.deokhugam_server.domain.book.client.NaverBookClient;
+import com.deokhugam.deokhugam_server.domain.book.client.OcrSpaceClient;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookCreateRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookUpdateRequest;
@@ -22,8 +24,6 @@ import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
-import com.deokhugam.deokhugam_server.domain.book.client.NaverBookClient;
-import com.deokhugam.deokhugam_server.domain.book.client.OcrSpaceClient;
 import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.book.repository.PopularBookRepository;
@@ -335,6 +335,72 @@ class BookServiceImplTest {
   }
 
   @Test
+  @DisplayName("도서 수정 시 ISBN은 변경되지 않는다")
+  void updateBook_isbnNotChanged() {
+    UUID bookId = UUID.randomUUID();
+    LocalDateTime now = LocalDateTime.now();
+
+    Book book = mock(Book.class);
+
+    BookUpdateRequest request = new BookUpdateRequest(
+      "수정된 제목",
+      "수정된 저자",
+      "수정된 출판사",
+      "수정된 설명",
+      LocalDate.of(2025, 1, 1)
+    );
+
+    BookSearchQueryDto queryDto = new BookSearchQueryDto(
+      bookId,
+      "수정된 제목",
+      "수정된 저자",
+      "수정된 설명",
+      "수정된 출판사",
+      LocalDate.of(2025, 1, 1),
+      "1234567890",
+      null,
+      0L,
+      0.0,
+      now,
+      now
+    );
+
+    BookDto expectedDto = new BookDto(
+      bookId,
+      "수정된 제목",
+      "수정된 저자",
+      "수정된 설명",
+      "수정된 출판사",
+      LocalDate.of(2025, 1, 1),
+      "1234567890",
+      null,
+      0,
+      0.0,
+      now,
+      now
+    );
+
+    when(bookRepository.findByIdAndIsDeletedFalse(bookId)).thenReturn(Optional.of(book));
+    when(book.getId()).thenReturn(bookId);
+    when(bookRepository.findBookDetail(bookId)).thenReturn(queryDto);
+    when(bookMapper.toDto(queryDto)).thenReturn(expectedDto);
+
+    BookDto result = bookService.updateBook(bookId, request, null);
+
+    assertNotNull(result);
+    assertEquals("1234567890", result.isbn());
+
+    verify(book).update(
+      eq("수정된 제목"),
+      eq("수정된 저자"),
+      eq("수정된 출판사"),
+      eq("수정된 설명"),
+      eq(null),
+      eq(LocalDate.of(2025, 1, 1))
+    );
+  }
+
+  @Test
   @DisplayName("도서 수정 실패 - 없는 도서")
   void updateBook_fail_notFound() {
     UUID bookId = UUID.randomUUID();
@@ -502,6 +568,7 @@ class BookServiceImplTest {
   void getBookInfo_success() {
     String isbn = "978-89-1234-567-8";
     String normalizedIsbn = "9788912345678";
+
     NaverBookDto expected = new NaverBookDto(
       "클린 코드",
       "로버트 마틴",


### PR DESCRIPTION
## 📋 관련 Issue

Closes #{issue_number}

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion:

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->
## 1. Controller 테스트 수정

BookController는 ApiResponse 래핑 구조가 아닌 DTO를 직접 반환하는 구조이므로
기존 테스트의 $.data.* 형태를 실제 응답 구조에 맞게 수정했습니다.

- $.data.id → $.id
- $.data.content → $.content

## 2. BookService 테스트 보강

핵심 요구사항 기반 테스트를 추가했습니다.

- ISBN 중복 생성 시 예외 발생
- 도서 수정 시 ISBN 변경 불가
- 물리 삭제(hard delete) 검증

### 🐛 버그 수정
- 

### ✨ 기능 추가 / 구현
- 

### ♻️ 리팩토링
- 

### ⚙️ 설정 변경
- 

## 🧪 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [ ] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [ ] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->

