### PR TITLE
[BE-31, BE-98]Fix: 알림 및 외부 API tests 추가 및 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/BookInfoClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/BookInfoClient.java
@@ -1,0 +1,8 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
+
+public interface BookInfoClient {
+
+  NaverBookDto searchByIsbn(String isbn);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClient.java
@@ -15,7 +15,7 @@ import org.springframework.web.client.RestClient;
 
 @Component
 @RequiredArgsConstructor
-public class NaverBookClient {
+public class NaverBookClient implements BookInfoClient {
 
   private static final DateTimeFormatter NAVER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
   private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]*>");
@@ -23,6 +23,7 @@ public class NaverBookClient {
   private final RestClient.Builder restClientBuilder;
   private final NaverApiProperties properties;
 
+  @Override
   public NaverBookDto searchByIsbn(String isbn) {
     try {
       NaverBookResponse response = restClientBuilder.build()

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/OcrSpaceClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/OcrSpaceClient.java
@@ -15,12 +15,15 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @RequiredArgsConstructor
-public class OcrSpaceClient {
+public class OcrSpaceClient implements TextExtractionClient {
+
+  private static final String PROVIDER = "OCR_SPACE";
 
   private final RestClient.Builder restClientBuilder;
   private final OcrSpaceProperties properties;
 
-  public String parseText(MultipartFile image) {
+  @Override
+  public TextExtractionResult extractText(MultipartFile image) {
     try {
       MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
       body.add("apikey", properties.key());
@@ -50,7 +53,7 @@ public class OcrSpaceClient {
         throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
       }
 
-      return parsedText;
+      return new TextExtractionResult(parsedText, PROVIDER);
     } catch (DeokhugamException e) {
       throw e;
     } catch (Exception e) {

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/TextExtractionClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/TextExtractionClient.java
@@ -1,0 +1,8 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface TextExtractionClient {
+
+  TextExtractionResult extractText(MultipartFile image);
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/TextExtractionResult.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/TextExtractionResult.java
@@ -1,0 +1,7 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+public record TextExtractionResult(
+    String text,
+    String provider
+) {
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -9,8 +9,9 @@ import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
-import com.deokhugam.deokhugam_server.domain.book.client.NaverBookClient;
-import com.deokhugam.deokhugam_server.domain.book.client.OcrSpaceClient;
+import com.deokhugam.deokhugam_server.domain.book.client.BookInfoClient;
+import com.deokhugam.deokhugam_server.domain.book.client.TextExtractionClient;
+import com.deokhugam.deokhugam_server.domain.book.client.TextExtractionResult;
 import com.deokhugam.deokhugam_server.domain.book.mapper.BookMapper;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.book.repository.PopularBookRepository;
@@ -49,8 +50,8 @@ public class BookServiceImpl implements BookService {
   private final BookRepository bookRepository;
   private final BookMapper bookMapper;
   private final PopularBookRepository popularBookRepository;
-  private final OcrSpaceClient ocrSpaceClient;
-  private final NaverBookClient naverBookClient;
+  private final TextExtractionClient textExtractionClient;
+  private final BookInfoClient bookInfoClient;
 
   @Override
   @Transactional
@@ -111,8 +112,8 @@ public class BookServiceImpl implements BookService {
   public String extractIsbn(MultipartFile image) {
     validateImageFile(image);
 
-    String ocrText = ocrSpaceClient.parseText(image);
-    String extractedIsbn = extractIsbnFromText(ocrText);
+    TextExtractionResult extractionResult = textExtractionClient.extractText(image);
+    String extractedIsbn = extractIsbnFromText(extractionResult.text());
     if (extractedIsbn == null) {
       throw new DeokhugamException(ErrorCode.ISBN_EXTRACTION_FAILED);
     }
@@ -204,7 +205,7 @@ public class BookServiceImpl implements BookService {
   @Override
   public NaverBookDto getBookInfo(String isbn) {
     String normalizedIsbn = normalizeIsbn(isbn);
-    return naverBookClient.searchByIsbn(normalizedIsbn);
+    return bookInfoClient.searchByIsbn(normalizedIsbn);
   }
 
   @Override

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClientTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClientTest.java
@@ -1,0 +1,147 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.deokhugam.deokhugam_server.domain.book.config.NaverApiProperties;
+import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.io.IOException;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class NaverBookClientTest {
+
+  private static final String NAVER_BOOK_URL = "https://openapi.naver.com/v1/search/book_adv.json";
+
+  private MockRestServiceServer server;
+  private NaverBookClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    server = MockRestServiceServer.bindTo(builder).build();
+    client = new NaverBookClient(
+        builder,
+        new NaverApiProperties("client-id", "client-secret", NAVER_BOOK_URL)
+    );
+  }
+
+  @Test
+  @DisplayName("성공: ISBN으로 네이버 도서 정보를 조회하고 HTML 태그를 제거한다")
+  void searchByIsbn_Success() {
+    // given
+    String isbn = "9788912345678";
+    String response = """
+        {
+          "items": [
+            {
+              "title": "<b>클린 코드</b>",
+              "image": "https://image.example/book.jpg",
+              "author": "로버트 <b>마틴</b>",
+              "publisher": "인사이트",
+              "pubdate": "20240131",
+              "isbn": "978-89-1234-567-8",
+              "description": "<b>좋은 코드</b>를 위한 설명"
+            }
+          ]
+        }
+        """;
+
+    server.expect(requestTo(NAVER_BOOK_URL + "?d_isbn=" + isbn))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Naver-Client-Id", "client-id"))
+        .andExpect(header("X-Naver-Client-Secret", "client-secret"))
+        .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+    // when
+    NaverBookDto result = client.searchByIsbn(isbn);
+
+    // then
+    assertThat(result.title()).isEqualTo("클린 코드");
+    assertThat(result.author()).isEqualTo("로버트 마틴");
+    assertThat(result.description()).isEqualTo("좋은 코드를 위한 설명");
+    assertThat(result.publishedDate()).isEqualTo(LocalDate.of(2024, 1, 31));
+    assertThat(result.isbn()).isEqualTo(isbn);
+    assertThat(result.thumbnailImage()).isEqualTo("https://image.example/book.jpg");
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 정확히 일치하는 ISBN이 없으면 첫 번째 검색 결과를 사용한다")
+  void searchByIsbn_FallbackToFirstItem_Success() {
+    // given
+    String isbn = "9788912345678";
+    String response = """
+        {
+          "items": [
+            {
+              "title": "대체 도서",
+              "image": null,
+              "author": "저자",
+              "publisher": "출판사",
+              "pubdate": "",
+              "isbn": "9791111111111",
+              "description": null
+            }
+          ]
+        }
+        """;
+
+    server.expect(requestTo(NAVER_BOOK_URL + "?d_isbn=" + isbn))
+        .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+    // when
+    NaverBookDto result = client.searchByIsbn(isbn);
+
+    // then
+    assertThat(result.title()).isEqualTo("대체 도서");
+    assertThat(result.publishedDate()).isNull();
+    assertThat(result.description()).isNull();
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 검색 결과가 없으면 도서 정보 없음 예외를 던진다")
+  void searchByIsbn_Fail_EmptyItems() {
+    // given
+    String isbn = "9788912345678";
+    server.expect(requestTo(NAVER_BOOK_URL + "?d_isbn=" + isbn))
+        .andRespond(withSuccess("{\"items\":[]}", MediaType.APPLICATION_JSON));
+
+    // when & then
+    assertThatThrownBy(() -> client.searchByIsbn(isbn))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.BOOK_INFO_NOT_FOUND);
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 네이버 API 호출이 실패하면 도서 정보 없음 예외로 변환한다")
+  void searchByIsbn_Fail_ApiException() {
+    // given
+    String isbn = "9788912345678";
+    server.expect(requestTo(NAVER_BOOK_URL + "?d_isbn=" + isbn))
+        .andRespond(withException(new IOException("network error")));
+
+    // when & then
+    assertThatThrownBy(() -> client.searchByIsbn(isbn))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.BOOK_INFO_NOT_FOUND);
+    server.verify();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/client/OcrSpaceClientTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/client/OcrSpaceClientTest.java
@@ -1,0 +1,152 @@
+package com.deokhugam.deokhugam_server.domain.book.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.deokhugam.deokhugam_server.domain.book.config.OcrSpaceProperties;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class OcrSpaceClientTest {
+
+  private static final String OCR_SPACE_URL = "https://api.ocr.space/parse/image";
+
+  private MockRestServiceServer server;
+  private OcrSpaceClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    server = MockRestServiceServer.bindTo(builder).build();
+    client = new OcrSpaceClient(builder, new OcrSpaceProperties("ocr-key", OCR_SPACE_URL));
+  }
+
+  @Test
+  @DisplayName("성공: OCR 결과 텍스트와 공급자 정보를 반환한다")
+  void extractText_Success() {
+    // given
+    MockMultipartFile image = new MockMultipartFile(
+        "file",
+        "book.png",
+        MediaType.IMAGE_PNG_VALUE,
+        "image".getBytes()
+    );
+    String response = """
+        {
+          "ParsedResults": [
+            {"ParsedText": "ISBN"},
+            {"ParsedText": "978-89-1234-567-8"}
+          ],
+          "IsErroredOnProcessing": false
+        }
+        """;
+
+    server.expect(requestTo(OCR_SPACE_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(content().string(containsString("ocr-key")))
+        .andExpect(content().string(containsString("eng")))
+        .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+    // when
+    TextExtractionResult result = client.extractText(image);
+
+    // then
+    assertThat(result.text()).isEqualTo("ISBN\n978-89-1234-567-8");
+    assertThat(result.provider()).isEqualTo("OCR_SPACE");
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("실패: OCR 처리 오류 응답이면 ISBN 추출 실패 예외를 던진다")
+  void extractText_Fail_ErroredResponse() {
+    // given
+    MockMultipartFile image = new MockMultipartFile(
+        "file",
+        "book.png",
+        MediaType.IMAGE_PNG_VALUE,
+        "image".getBytes()
+    );
+    String response = """
+        {
+          "ParsedResults": [{"ParsedText": "ignored"}],
+          "IsErroredOnProcessing": true
+        }
+        """;
+
+    server.expect(requestTo(OCR_SPACE_URL))
+        .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+    // when & then
+    assertThatThrownBy(() -> client.extractText(image))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.ISBN_EXTRACTION_FAILED);
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("실패: OCR 결과 텍스트가 비어 있으면 ISBN 추출 실패 예외를 던진다")
+  void extractText_Fail_BlankParsedText() {
+    // given
+    MockMultipartFile image = new MockMultipartFile(
+        "file",
+        "book.png",
+        MediaType.IMAGE_PNG_VALUE,
+        "image".getBytes()
+    );
+    String response = """
+        {
+          "ParsedResults": [{"ParsedText": "   "}],
+          "IsErroredOnProcessing": false
+        }
+        """;
+
+    server.expect(requestTo(OCR_SPACE_URL))
+        .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+    // when & then
+    assertThatThrownBy(() -> client.extractText(image))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.ISBN_EXTRACTION_FAILED);
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("실패: OCR API 호출이 실패하면 ISBN 추출 실패 예외로 변환한다")
+  void extractText_Fail_ApiException() {
+    // given
+    MockMultipartFile image = new MockMultipartFile(
+        "file",
+        "book.png",
+        MediaType.IMAGE_PNG_VALUE,
+        "image".getBytes()
+    );
+
+    server.expect(requestTo(OCR_SPACE_URL))
+        .andRespond(withException(new IOException("network error")));
+
+    // when & then
+    assertThatThrownBy(() -> client.extractText(image))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.ISBN_EXTRACTION_FAILED);
+    server.verify();
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
@@ -13,8 +13,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.deokhugam.deokhugam_server.domain.book.client.NaverBookClient;
-import com.deokhugam.deokhugam_server.domain.book.client.OcrSpaceClient;
+import com.deokhugam.deokhugam_server.domain.book.client.BookInfoClient;
+import com.deokhugam.deokhugam_server.domain.book.client.TextExtractionClient;
+import com.deokhugam.deokhugam_server.domain.book.client.TextExtractionResult;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookCreateRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookUpdateRequest;
@@ -58,10 +59,10 @@ class BookServiceImplTest {
   private BookMapper bookMapper;
 
   @Mock
-  private OcrSpaceClient ocrSpaceClient;
+  private TextExtractionClient textExtractionClient;
 
   @Mock
-  private NaverBookClient naverBookClient;
+  private BookInfoClient bookInfoClient;
 
   @InjectMocks
   private BookServiceImpl bookService;
@@ -486,7 +487,8 @@ class BookServiceImplTest {
       "dummy".getBytes()
     );
 
-    when(ocrSpaceClient.parseText(image)).thenReturn("ISBN 978-89-1234-567-8");
+    when(textExtractionClient.extractText(image))
+        .thenReturn(new TextExtractionResult("ISBN 978-89-1234-567-8", "OCR_SPACE"));
 
     String result = bookService.extractIsbn(image);
 
@@ -503,7 +505,8 @@ class BookServiceImplTest {
       "dummy".getBytes()
     );
 
-    when(ocrSpaceClient.parseText(image)).thenReturn("ISBN 89-1234-567X");
+    when(textExtractionClient.extractText(image))
+        .thenReturn(new TextExtractionResult("ISBN 89-1234-567X", "OCR_SPACE"));
 
     String result = bookService.extractIsbn(image);
 
@@ -554,7 +557,8 @@ class BookServiceImplTest {
       "dummy".getBytes()
     );
 
-    when(ocrSpaceClient.parseText(image)).thenReturn("no isbn text");
+    when(textExtractionClient.extractText(image))
+        .thenReturn(new TextExtractionResult("no isbn text", "OCR_SPACE"));
 
     DeokhugamException exception = assertThrows(DeokhugamException.class, () ->
       bookService.extractIsbn(image)
@@ -579,7 +583,7 @@ class BookServiceImplTest {
       "https://image.test/book.png"
     );
 
-    when(naverBookClient.searchByIsbn(normalizedIsbn)).thenReturn(expected);
+    when(bookInfoClient.searchByIsbn(normalizedIsbn)).thenReturn(expected);
 
     NaverBookDto result = bookService.getBookInfo(isbn);
 
@@ -596,7 +600,7 @@ class BookServiceImplTest {
     String isbn = "978-89-1234-567-8";
     String normalizedIsbn = "9788912345678";
 
-    when(naverBookClient.searchByIsbn(normalizedIsbn))
+    when(bookInfoClient.searchByIsbn(normalizedIsbn))
       .thenThrow(new DeokhugamException(ErrorCode.BOOK_INFO_NOT_FOUND));
 
     DeokhugamException exception = assertThrows(DeokhugamException.class, () ->

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImplTest.java
@@ -1,0 +1,143 @@
+package com.deokhugam.deokhugam_server.domain.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.domain.notification.dto.request.NotificationSearchRequest;
+import com.deokhugam.deokhugam_server.domain.notification.entity.Notification;
+import com.deokhugam.deokhugam_server.domain.notification.entity.NotificationType;
+import com.deokhugam.deokhugam_server.global.config.QueryDslConfig;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QueryDslConfig.class)
+class NotificationRepositoryImplTest {
+
+  private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 4, 28, 10, 0);
+  private static final LocalDateTime FIXED_OLD = FIXED_NOW.minusDays(1);
+
+  @Autowired private NotificationRepository notificationRepository;
+  @Autowired private EntityManager em;
+
+  private UUID userId;
+  private UUID otherUserId;
+  private UUID newestNotificationId;
+
+  @BeforeEach
+  void setUp() {
+    userId = UUID.randomUUID();
+    otherUserId = UUID.randomUUID();
+
+    Notification oldNotification = createNotification(userId, "이전 알림", FIXED_OLD);
+    Notification newestNotification = createNotification(userId, "최신 알림", FIXED_NOW);
+    createNotification(otherUserId, "다른 사용자 알림", FIXED_NOW);
+
+    Notification readNotification = createNotification(userId, "읽은 알림", FIXED_NOW.minusHours(1));
+    readNotification.markAsRead();
+
+    Notification deletedNotification = createNotification(userId, "삭제된 알림", FIXED_NOW.minusHours(2));
+    deletedNotification.delete();
+
+    em.flush();
+    newestNotificationId = newestNotification.getId();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("성공: 사용자별 알림을 최신순으로 조회한다")
+  void searchNotifications_Desc_Success() {
+    // given
+    NotificationSearchRequest request = new NotificationSearchRequest();
+    request.setUserId(userId);
+    request.setDirection("DESC");
+    request.setLimit(10);
+
+    // when
+    List<Notification> result = notificationRepository.searchNotifications(request);
+
+    // then
+    assertThat(result).extracting(Notification::getContent)
+        .containsExactly("최신 알림", "읽은 알림", "이전 알림");
+  }
+
+  @Test
+  @DisplayName("성공: 커서 이후의 알림만 조회한다")
+  void searchNotifications_Cursor_Success() {
+    // given
+    NotificationSearchRequest request = new NotificationSearchRequest();
+    request.setUserId(userId);
+    request.setAfter(FIXED_NOW);
+    request.setCursor(newestNotificationId.toString());
+    request.setDirection("DESC");
+    request.setLimit(10);
+
+    // when
+    List<Notification> result = notificationRepository.searchNotifications(request);
+
+    // then
+    assertThat(result).extracting(Notification::getContent)
+        .containsExactly("읽은 알림", "이전 알림");
+  }
+
+  @Test
+  @DisplayName("성공: 오름차순으로 알림을 조회한다")
+  void searchNotifications_Asc_Success() {
+    // given
+    NotificationSearchRequest request = new NotificationSearchRequest();
+    request.setUserId(userId);
+    request.setDirection("ASC");
+    request.setLimit(10);
+
+    // when
+    List<Notification> result = notificationRepository.searchNotifications(request);
+
+    // then
+    assertThat(result).extracting(Notification::getContent)
+        .containsExactly("이전 알림", "읽은 알림", "최신 알림");
+  }
+
+  @Test
+  @DisplayName("성공: 읽지 않은 알림만 조회한다")
+  void findUnreadByUserId_Success() {
+    // when
+    List<Notification> result = notificationRepository.findUnreadByUserId(userId);
+
+    // then
+    assertThat(result).extracting(Notification::getContent)
+        .containsExactlyInAnyOrder("이전 알림", "최신 알림");
+  }
+
+  @Test
+  @DisplayName("성공: 삭제되지 않은 사용자 알림 수만 계산한다")
+  void countByUserId_Success() {
+    // when
+    long count = notificationRepository.countByUserId(userId);
+
+    // then
+    assertThat(count).isEqualTo(3);
+  }
+
+  private Notification createNotification(UUID targetUserId, String content, LocalDateTime createdAt) {
+    Notification notification = new Notification(
+        UUID.randomUUID(),
+        targetUserId,
+        NotificationType.REVIEW_COMMENTED,
+        content
+    );
+    ReflectionTestUtils.setField(notification, "createdAt", createdAt);
+    ReflectionTestUtils.setField(notification, "updatedAt", createdAt);
+    em.persist(notification);
+    return notification;
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/repository/NotificationRepositoryImplTest.java
@@ -39,8 +39,8 @@ class NotificationRepositoryImplTest {
     userId = UUID.randomUUID();
     otherUserId = UUID.randomUUID();
 
-    Notification oldNotification = createNotification(userId, "이전 알림", FIXED_OLD);
     Notification newestNotification = createNotification(userId, "최신 알림", FIXED_NOW);
+    createNotification(userId, "이전 알림", FIXED_OLD);
     createNotification(otherUserId, "다른 사용자 알림", FIXED_NOW);
 
     Notification readNotification = createNotification(userId, "읽은 알림", FIXED_NOW.minusHours(1));
@@ -51,6 +51,13 @@ class NotificationRepositoryImplTest {
 
     em.flush();
     newestNotificationId = newestNotification.getId();
+
+    updateCreatedAt("최신 알림", FIXED_NOW);
+    updateCreatedAt("읽은 알림", FIXED_NOW.minusHours(1));
+    updateCreatedAt("삭제된 알림", FIXED_NOW.minusHours(2));
+    updateCreatedAt("이전 알림", FIXED_OLD);
+    updateCreatedAt("다른 사용자 알림", FIXED_NOW);
+
     em.clear();
   }
 
@@ -139,5 +146,12 @@ class NotificationRepositoryImplTest {
     ReflectionTestUtils.setField(notification, "updatedAt", createdAt);
     em.persist(notification);
     return notification;
+  }
+
+  private void updateCreatedAt(String content, LocalDateTime createdAt) {
+    em.createNativeQuery("UPDATE notifications SET created_at = ?1 WHERE content = ?2")
+        .setParameter(1, createdAt)
+        .setParameter(2, content)
+        .executeUpdate();
   }
 }


### PR DESCRIPTION
## 🔗 Notion Task 링크
- https://www.notion.so/Notification-JUnit5-Mockito-3506e443c288818e990ee82df917610c?source=copy_link
- https://www.notion.so/API-tests-3506e443c28880478f08ca44c2117bed?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- 네이버 도서 API 클라이언트 테스트 추가
- OCR.space 클라이언트 테스트 추가
- OCR 결과 전달용 TextExtractionResult DTO 추가
- 외부 도서 정보 조회 추상화 인터페이스 BookInfoClient 추가
- OCR 텍스트 추출 추상화 인터페이스 TextExtractionClient 추가

### ♻️ 리팩토링
- BookServiceImpl이 NaverBookClient, OcrSpaceClient 구현체에 직접 의존하지 않고 BookInfoClient, TextExtractionClient 인터페이스에 의존하도록 변경
- NaverBookClient가 BookInfoClient를 구현하도록 변경
- OcrSpaceClient가 TextExtractionClient를 구현하도록 변경
- OCR 클라이언트 반환값을 단순 문자열에서 TextExtractionResult로 변경
- API 명세에 맞춰 /api/books/isbn/ocr 응답은 기존 문자열 ISBN 형태 유지

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
