### PR TITLE
[BE-99] Feat: S3 날짜별 로그 적재 구현 및 환경변수 추가

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/ErrorCode.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/exception/ErrorCode.java
@@ -64,7 +64,8 @@ public enum ErrorCode {
 
   // [STORAGE] 파일 저장소
   S3_UPLOAD_FAILED(500, "S701", "파일 업로드에 실패했습니다."),
-  S3_DELETE_FAILED(500, "S702", "파일 삭제에 실패했습니다.");
+  S3_DELETE_FAILED(500, "S702", "파일 삭제에 실패했습니다."),
+  S3_LOG_UPLOAD_FAILED(500, "S703", "로그 파일 업로드에 실패했습니다.");
 
   private final int status;
   private final String code;

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/log/DailyLogS3Uploader.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/log/DailyLogS3Uploader.java
@@ -1,0 +1,73 @@
+package com.deokhugam.deokhugam_server.global.log;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyLogS3Uploader {
+
+  private final S3Client s3Client;
+
+  @Value("${deokhugam.log.s3.bucket:}")
+  private String bucket;
+
+  @Value("${deokhugam.log.s3.prefix:app}")
+  private String prefix;
+
+  @Value("${deokhugam.log.s3.delete-after-upload:false}")
+  private boolean deleteAfterUpload;
+
+  public boolean upload(LocalDate logDate, Path logFile) {
+    if (bucket == null || bucket.isBlank()) {
+      log.warn("Daily log S3 upload skipped because S3_LOG_BUCKET is empty");
+      return false;
+    }
+    if (!Files.isRegularFile(logFile)) {
+      log.warn("Daily log S3 upload skipped because log file does not exist: {}", logFile);
+      return false;
+    }
+
+    String key = buildKey(logDate, logFile.getFileName().toString());
+    try {
+      PutObjectRequest request = PutObjectRequest.builder()
+          .bucket(bucket)
+          .key(key)
+          .contentType("text/plain; charset=UTF-8")
+          .build();
+
+      s3Client.putObject(request, logFile);
+      if (deleteAfterUpload) {
+        Files.deleteIfExists(logFile);
+      }
+      log.info("Daily log S3 upload success: s3://{}/{}", bucket, key);
+      return true;
+    } catch (Exception e) {
+      log.error("Daily log S3 upload failed: {}", e.getMessage(), e);
+      throw new DeokhugamException(ErrorCode.S3_LOG_UPLOAD_FAILED);
+    }
+  }
+
+  String buildKey(LocalDate logDate, String fileName) {
+    String normalizedPrefix = prefix == null || prefix.isBlank()
+        ? "app"
+        : prefix.replaceAll("^/+", "").replaceAll("/+$", "");
+    return "%s/%04d/%02d/%02d/%s".formatted(
+        normalizedPrefix,
+        logDate.getYear(),
+        logDate.getMonthValue(),
+        logDate.getDayOfMonth(),
+        fileName
+    );
+  }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadScheduler.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadScheduler.java
@@ -1,0 +1,41 @@
+package com.deokhugam.deokhugam_server.global.scheduler;
+
+import com.deokhugam.deokhugam_server.global.log.DailyLogS3Uploader;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyLogUploadScheduler {
+
+  private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+  private final DailyLogS3Uploader dailyLogS3Uploader;
+  private final Clock clock;
+
+  @Value("${deokhugam.log.s3.local-path:./logs}")
+  private String localPath;
+
+  @Autowired
+  public DailyLogUploadScheduler(DailyLogS3Uploader dailyLogS3Uploader) {
+    this(dailyLogS3Uploader, Clock.system(SEOUL_ZONE));
+  }
+
+  DailyLogUploadScheduler(DailyLogS3Uploader dailyLogS3Uploader, Clock clock) {
+    this.dailyLogS3Uploader = dailyLogS3Uploader;
+    this.clock = clock;
+  }
+
+  @Scheduled(cron = "${deokhugam.log.s3.upload-cron:0 10 0 * * *}", zone = "Asia/Seoul")
+  public void uploadYesterdayLog() {
+    LocalDate targetDate = LocalDate.now(clock).minusDays(1);
+    Path targetFile = Path.of(localPath, "deokhugam.%s.log".formatted(targetDate));
+
+    dailyLogS3Uploader.upload(targetDate, targetFile);
+  }
+}

--- a/deokhugam/src/main/resources/application.yml
+++ b/deokhugam/src/main/resources/application.yml
@@ -20,8 +20,20 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local-h2}   # 기본값은 즉시 실행 가능한 H2 로컬 프로필
 
 logging:
+  file:
+    path: ${LOG_FILE_PATH:./logs}
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%X{clientIp}] %-5level %logger{36} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%X{clientIp}] %-5level %logger{36} - %msg%n"
+
+deokhugam:
+  log:
+    s3:
+      bucket: ${S3_LOG_BUCKET:}
+      prefix: ${S3_LOG_PREFIX:app}
+      local-path: ${LOG_FILE_PATH:./logs}
+      upload-cron: ${S3_LOG_UPLOAD_CRON:0 10 0 * * *}
+      delete-after-upload: ${S3_LOG_DELETE_AFTER_UPLOAD:false}
 
 management:
   endpoints:

--- a/deokhugam/src/main/resources/logback-spring.xml
+++ b/deokhugam/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <springProperty name="LOG_PATH" source="logging.file.path" defaultValue="./logs"/>
+  <springProperty name="CONSOLE_PATTERN" source="logging.pattern.console"
+    defaultValue="%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%X{clientIp}] %-5level %logger{36} - %msg%n"/>
+  <springProperty name="FILE_PATTERN" source="logging.pattern.file"
+    defaultValue="%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%X{clientIp}] %-5level %logger{36} - %msg%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_PATH}/deokhugam.log</file>
+    <encoder>
+      <pattern>${FILE_PATTERN}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/deokhugam.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/log/DailyLogS3UploaderTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/log/DailyLogS3UploaderTest.java
@@ -1,0 +1,118 @@
+package com.deokhugam.deokhugam_server.global.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@ExtendWith(MockitoExtension.class)
+class DailyLogS3UploaderTest {
+
+  @Mock
+  private S3Client s3Client;
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  @DisplayName("성공: 날짜별 로그 파일을 S3 app/yyyy/MM/dd 경로로 업로드한다")
+  void upload_Success() throws Exception {
+    DailyLogS3Uploader uploader = uploader("deokhugam-logs-297904", "app", false);
+    LocalDate logDate = LocalDate.of(2026, 4, 28);
+    Path logFile = Files.writeString(tempDir.resolve("deokhugam.2026-04-28.log"), "test log");
+    when(s3Client.putObject(any(PutObjectRequest.class), eq(logFile)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    boolean result = uploader.upload(logDate, logFile);
+
+    ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3Client).putObject(requestCaptor.capture(), eq(logFile));
+    PutObjectRequest request = requestCaptor.getValue();
+    assertThat(result).isTrue();
+    assertThat(request.bucket()).isEqualTo("deokhugam-logs-297904");
+    assertThat(request.key()).isEqualTo("app/2026/04/28/deokhugam.2026-04-28.log");
+    assertThat(request.contentType()).isEqualTo("text/plain; charset=UTF-8");
+  }
+
+  @Test
+  @DisplayName("성공: 로그 버킷이 없으면 업로드를 건너뛴다")
+  void upload_Skip_WhenBucketBlank() throws Exception {
+    DailyLogS3Uploader uploader = uploader("", "app", false);
+    Path logFile = Files.writeString(tempDir.resolve("deokhugam.2026-04-28.log"), "test log");
+
+    boolean result = uploader.upload(LocalDate.of(2026, 4, 28), logFile);
+
+    assertThat(result).isFalse();
+    verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+  }
+
+  @Test
+  @DisplayName("성공: 로그 파일이 없으면 업로드를 건너뛴다")
+  void upload_Skip_WhenFileDoesNotExist() {
+    DailyLogS3Uploader uploader = uploader("deokhugam-logs-297904", "app", false);
+    Path missingFile = tempDir.resolve("deokhugam.2026-04-28.log");
+
+    boolean result = uploader.upload(LocalDate.of(2026, 4, 28), missingFile);
+
+    assertThat(result).isFalse();
+    verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+  }
+
+  @Test
+  @DisplayName("성공: 업로드 후 삭제 설정이 켜져 있으면 로컬 로그 파일을 삭제한다")
+  void upload_DeletesLocalFile_WhenDeleteAfterUploadIsEnabled() throws Exception {
+    DailyLogS3Uploader uploader = uploader("deokhugam-logs-297904", "app", true);
+    Path logFile = Files.writeString(tempDir.resolve("deokhugam.2026-04-28.log"), "test log");
+    when(s3Client.putObject(any(PutObjectRequest.class), eq(logFile)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    boolean result = uploader.upload(LocalDate.of(2026, 4, 28), logFile);
+
+    assertThat(result).isTrue();
+    assertThat(logFile).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("실패: S3 업로드 실패 시 로그 업로드 예외를 던진다")
+  void upload_ThrowsException_WhenS3UploadFails() throws Exception {
+    DailyLogS3Uploader uploader = uploader("deokhugam-logs-297904", "app", false);
+    Path logFile = Files.writeString(tempDir.resolve("deokhugam.2026-04-28.log"), "test log");
+    when(s3Client.putObject(any(PutObjectRequest.class), eq(logFile)))
+        .thenThrow(S3Exception.builder().message("upload failed").build());
+
+    assertThatThrownBy(() -> uploader.upload(LocalDate.of(2026, 4, 28), logFile))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.S3_LOG_UPLOAD_FAILED);
+  }
+
+  private DailyLogS3Uploader uploader(String bucket, String prefix, boolean deleteAfterUpload) {
+    DailyLogS3Uploader uploader = new DailyLogS3Uploader(s3Client);
+    ReflectionTestUtils.setField(uploader, "bucket", bucket);
+    ReflectionTestUtils.setField(uploader, "prefix", prefix);
+    ReflectionTestUtils.setField(uploader, "deleteAfterUpload", deleteAfterUpload);
+    return uploader;
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadSchedulerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadSchedulerTest.java
@@ -1,0 +1,44 @@
+package com.deokhugam.deokhugam_server.global.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.global.log.DailyLogS3Uploader;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DailyLogUploadSchedulerTest {
+
+  @Mock
+  private DailyLogS3Uploader dailyLogS3Uploader;
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  @DisplayName("성공: 매일 전날 날짜의 로그 파일 업로드를 요청한다")
+  void uploadYesterdayLog_UploadsPreviousDayLog() {
+    Clock fixedClock = Clock.fixed(
+        Instant.parse("2026-04-28T01:00:00Z"),
+        ZoneId.of("Asia/Seoul")
+    );
+    DailyLogUploadScheduler scheduler = new DailyLogUploadScheduler(dailyLogS3Uploader, fixedClock);
+    ReflectionTestUtils.setField(scheduler, "localPath", tempDir.toString());
+
+    scheduler.uploadYesterdayLog();
+
+    LocalDate expectedDate = LocalDate.of(2026, 4, 27);
+    Path expectedFile = tempDir.resolve("deokhugam.2026-04-27.log");
+    verify(dailyLogS3Uploader).upload(expectedDate, expectedFile);
+  }
+}

--- a/task-definition.json
+++ b/task-definition.json
@@ -36,6 +36,22 @@
           "value": "deokhugam-storage"
         },
         {
+          "name": "LOG_FILE_PATH",
+          "value": "/app/logs"
+        },
+        {
+          "name": "S3_LOG_BUCKET",
+          "value": "deokhugam-logs-297904"
+        },
+        {
+          "name": "S3_LOG_PREFIX",
+          "value": "app"
+        },
+        {
+          "name": "S3_LOG_DELETE_AFTER_UPLOAD",
+          "value": "false"
+        },
+        {
           "name": "SPRING_PROFILES_ACTIVE",
           "value": "dev"
         }


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/S3-3506e443c288801f9a2bf13cc133ab94?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- 날짜별 애플리케이션 로그 파일 생성을 위한 Logback 설정 추가
- 전날 로그 파일을 S3 로그 버킷에 업로드하는 DailyLogS3Uploader 구현
- 매일 00:10(Asia/Seoul) 기준 전날 로그 파일을 S3에 적재하는 스케줄러 구현
- S3 로그 업로드 성공, 스킵, 실패 케이스에 대한 단위 테스트 추가

### ♻️ 리팩토링
- 이미지 업로드용 S3Util과 로그 업로드 책임을 분리해 로그 전용 업로더로 구성

### ⚙️ 설정 변경
- application.yml에 로그 파일 경로 및 S3 로그 적재 설정 추가
- logback-spring.xml 추가로 콘솔 로그와 파일 로그를 함께 출력하도록 설정
- task-definition.json에 로그 적재용 ECS 환경변수 추가
- S3 로그 업로드 실패용 S3_LOG_UPLOAD_FAILED 에러 코드 추가

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항

