### PR TITLE
[BE-100] Dashboard repository 쿼리 최적화

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
@@ -10,6 +10,7 @@ import com.deokhugam.deokhugam_server.domain.book.service.BookService;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -94,7 +95,7 @@ public class BookController {
           @RequestParam(defaultValue = "DAILY") Period period,
           @RequestParam(defaultValue = "ASC") String direction,
           @RequestParam(required = false) String cursor,
-          @RequestParam(required = false) String after,
+          @RequestParam(required = false) LocalDateTime after,
           @RequestParam(defaultValue = "50") int limit
   ) {
     CursorPageResponse<PopularBookDto> popularBooks = bookService.searchPopularBooks(

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/PopularBookRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/PopularBookRepository.java
@@ -15,27 +15,29 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
 
   List<PopularBook> findAllByPeriodTypeAndCalculatedDate(Period periodType, LocalDate calculatedDate);
 
-  @Query("SELECT p FROM PopularBook p "
-      + "JOIN FETCH p.book b " +
-      "WHERE p.periodType = :period " +
-      "AND (" +
-    "  CAST(:after AS LocalDateTime) IS NULL OR " +
-    "  (CAST(:direction AS string) = 'DESC' AND (p.createdAt < :after OR (p.createdAt = :after AND p.rankOrder > :cursor))) OR " +
-    "  (CAST(:direction AS string) = 'ASC' AND (p.createdAt > :after OR (p.createdAt = :after AND p.rankOrder < :cursor)))" +
-      ") " +
-      "ORDER BY " +
-    "  CASE WHEN CAST(:direction AS string) = 'DESC' THEN p.createdAt END DESC, " +
-    "  CASE WHEN CAST(:direction AS string) = 'DESC' THEN p.rankOrder END ASC, " +
-    "  CASE WHEN CAST(:direction AS string) = 'ASC' THEN p.createdAt END ASC, " +
-    "  CASE WHEN CAST(:direction AS string) = 'ASC' THEN p.rankOrder END DESC")
-  List<PopularBook> findPopularBooksWithPaging(
-      @Param("period") Period period,
-      @Param("direction") String direction,
-      @Param("cursor") Integer cursor,
-      @Param("after") LocalDateTime after,
-      @Param("limit") Limit limit
+  @Query("SELECT p FROM PopularBook p " +
+    "JOIN FETCH p.book b " +
+    "WHERE p.periodType = :period " +
+    "AND (:after IS NULL OR p.createdAt < :after OR (p.createdAt = :after AND p.rankOrder > :cursor)) " +
+    "ORDER BY p.createdAt DESC, p.rankOrder DESC")
+  List<PopularBook> findPopularBooksDesc(
+    @Param("period") Period period,
+    @Param("cursor") Integer cursor,
+    @Param("after") LocalDateTime after,
+    Limit limit
   );
 
+  @Query("SELECT p FROM PopularBook p " +
+    "JOIN FETCH p.book b " +
+    "WHERE p.periodType = :period " +
+    "AND (:after IS NULL OR p.createdAt > :after OR (p.createdAt = :after AND p.rankOrder < :cursor)) " +
+    "ORDER BY p.createdAt ASC, p.rankOrder ASC")
+  List<PopularBook> findPopularBooksAsc(
+    @Param("period") Period period,
+    @Param("cursor") Integer cursor,
+    @Param("after") LocalDateTime after,
+    Limit limit
+  );
   long countByPeriodType(Period periodType);
 
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookService.java
@@ -8,6 +8,7 @@ import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,7 +27,7 @@ public interface BookService {
   void deleteBook(UUID bookId);
 
   CursorPageResponse<PopularBookDto> searchPopularBooks(
-    Period period, String direction, String cursor, String after, int limit
+    Period period, String direction, String cursor, LocalDateTime after, int limit
   );
 
   NaverBookDto getBookInfo(String isbn);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -19,10 +19,7 @@ import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -172,25 +169,26 @@ public class BookServiceImpl implements BookService {
 
   @Override
   public CursorPageResponse<PopularBookDto> searchPopularBooks(
-    Period period, String direction, String cursor, String after, int limit
+    Period period, String direction, String cursor, LocalDateTime after, int limit
   ) {
-    Integer cursorRank = parseCursorRank(cursor);
-    LocalDateTime afterLdt = parseLocalDateTime(after);
+    Integer cursorInt = (cursor != null) ? Integer.parseInt(cursor) : null;
+    Limit limitWithNext = Limit.of(limit + 1);
 
-    List<PopularBook> popularBooks = popularBookRepository.findPopularBooksWithPaging(
-      period, direction.toUpperCase(), cursorRank, afterLdt,
-      Limit.of(limit + 1)
-    );
+    List<PopularBook> results = "DESC".equalsIgnoreCase(direction)
+      ? popularBookRepository.findPopularBooksDesc(period, cursorInt, after, limitWithNext)
+      : popularBookRepository.findPopularBooksAsc(period, cursorInt, after, limitWithNext);
 
+    boolean hasNext = results.size() > limit;
+    List<PopularBook> content = hasNext ? results.subList(0, limit) : results;
+
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+    if (!content.isEmpty()) {
+      PopularBook lastItem = content.get(content.size() - 1);
+      nextCursor = String.valueOf(lastItem.getRankOrder());
+      nextAfter = lastItem.getCreatedAt();
+    }
     long totalElements = popularBookRepository.countByPeriodType(period);
-
-    boolean hasNext = popularBooks.size() > limit;
-    List<PopularBook> content = hasNext ? popularBooks.subList(0, limit) : popularBooks;
-
-    String nextCursor =
-      content.isEmpty() ? null : String.valueOf(content.get(content.size() - 1).getRankOrder());
-    LocalDateTime nextAfter =
-      content.isEmpty() ? null : content.get(content.size() - 1).getCreatedAt();
 
     return new CursorPageResponse<>(
       content.stream().map(bookMapper::toPopularDto).toList(),
@@ -286,22 +284,6 @@ public class BookServiceImpl implements BookService {
       case "title" -> item.title();
       default -> item.title();
     };
-  }
-
-  private LocalDateTime parseLocalDateTime(String after) {
-    if (after == null || after.isBlank()) {
-      return null;
-    }
-
-    try {
-      ZoneId kstZone = ZoneId.of("Asia/Seoul");
-      if (after.endsWith("Z")) {
-        return LocalDateTime.ofInstant(Instant.parse(after), kstZone);
-      }
-      return LocalDateTime.parse(after);
-    } catch (Exception e) {
-      return LocalDate.parse(after.substring(0, 10)).atStartOfDay();
-    }
   }
 
   private String normalizeOrderBy(String orderBy) {

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/controller/ReviewController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/controller/ReviewController.java
@@ -12,6 +12,7 @@ import com.deokhugam.deokhugam_server.global.type.Period;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -102,9 +103,9 @@ public class ReviewController {
   @GetMapping("/popular")
   public ResponseEntity<CursorPageResponse<PopularReviewDto>> searchPopularReview(
       @RequestParam(defaultValue = "DAILY") Period period,
-      @RequestParam(defaultValue = "DESC") String direction, // 수정됨: 인기 순위이므로 DESC가 기본
+      @RequestParam(defaultValue = "DESC") String direction,
       @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) String after,
+      @RequestParam(required = false) LocalDateTime after,
       @RequestParam(defaultValue = "50") int limit
   ) {
     CursorPageResponse<PopularReviewDto> popularReviews = reviewService.searchPopularReviews(period, direction, cursor, after, limit);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepository.java
@@ -35,25 +35,28 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
   List<PopularReview> findAllByPeriodTypeAndCalculatedDate(Period periodType,
       LocalDate calculatedDate);
 
-  @Query("select p from PopularReview p " +
-      "join fetch p.review r " +
-      "WHERE p.periodType = :period " +
-      "AND (" +
-    "  CAST(:after AS LocalDateTime) IS NULL OR " +
-    "  (CAST(:direction AS string) = 'DESC' AND (p.createdAt < :after OR (p.createdAt = :after AND p.rankOrder > :cursor))) OR " +
-    "  (CAST(:direction AS string) = 'ASC' AND (p.createdAt > :after OR (p.createdAt = :after AND p.rankOrder < :cursor)))" +
-      ") " +
-      "ORDER BY " +
-    "  CASE WHEN CAST(:direction AS string) = 'DESC' THEN p.createdAt END DESC, " +
-    "  CASE WHEN CAST(:direction AS string) = 'DESC' THEN p.rankOrder END ASC, " +
-    "  CASE WHEN CAST(:direction AS string) = 'ASC' THEN p.createdAt END ASC, " +
-    "  CASE WHEN CAST(:direction AS string) = 'ASC' THEN p.rankOrder END DESC")
-  List<PopularReview> findPopularReviewsWithPaging(
-      @Param("period") Period period,
-      @Param("direction") String direction,
-      @Param("cursor") Integer cursor,
-      @Param("after") LocalDateTime after,
-      @Param("limit") Limit limit
+  @Query("SELECT r FROM PopularReview r " +
+    "JOIN FETCH r.review rev " +
+    "WHERE r.periodType = :period " +
+    "AND (:after IS NULL OR r.createdAt < :after OR (r.createdAt = :after AND r.rankOrder > :cursor)) " +
+    "ORDER BY r.createdAt DESC, r.rankOrder DESC")
+  List<PopularReview> findPopularReviewsDesc(
+    @Param("period") Period period,
+    @Param("cursor") Integer cursor,
+    @Param("after") LocalDateTime after,
+    Limit limit
+  );
+
+  @Query("SELECT r FROM PopularReview r " +
+    "JOIN FETCH r.review rev " +
+    "WHERE r.periodType = :period " +
+    "AND (:after IS NULL OR r.createdAt > :after OR (r.createdAt = :after AND r.rankOrder < :cursor)) " +
+    "ORDER BY r.createdAt ASC, r.rankOrder ASC")
+  List<PopularReview> findPopularReviewsAsc(
+    @Param("period") Period period,
+    @Param("cursor") Integer cursor,
+    @Param("after") LocalDateTime after,
+    Limit limit
   );
 
   long countByPeriodType(Period periodType);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepository.java
@@ -1,6 +1,7 @@
 package com.deokhugam.deokhugam_server.domain.review.repository;
 
 import com.deokhugam.deokhugam_server.domain.review.entity.PopularReview;
+import com.deokhugam.deokhugam_server.domain.user.dto.response.UserScoreDto;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,6 +25,12 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
       @Param("period") Period period,
       @Param("date") LocalDate date
   );
+
+  @Query("SELECT new com.deokhugam.deokhugam_server.domain.user.dto.response.UserScoreDto(pr.review.user.id, SUM(pr.score)) " +
+    "FROM PopularReview pr " +
+    "WHERE pr.periodType = :periodType AND pr.calculatedDate = :date " +
+    "GROUP BY pr.review.user.id")
+  List<UserScoreDto> sumAllUserScoresByPeriod(@Param("periodType") Period periodType, @Param("date") LocalDate date);
 
   List<PopularReview> findAllByPeriodTypeAndCalculatedDate(Period periodType,
       LocalDate calculatedDate);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewService.java
@@ -2,7 +2,6 @@ package com.deokhugam.deokhugam_server.domain.review.service;
 
 import static com.deokhugam.deokhugam_server.global.util.PeriodUtil.getStartDate;
 
-import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.PopularReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.review.entity.PopularReview;
@@ -11,9 +10,10 @@ import com.deokhugam.deokhugam_server.domain.review.event.ReviewRankedEvent;
 import com.deokhugam.deokhugam_server.domain.review.mapper.ReviewMapper;
 import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
-import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
+import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,8 +32,6 @@ public class PopularReviewService {
 
   private final ReviewRepository reviewRepository;
   private final PopularReviewRepository popularReviewRepository;
-  private final BookRepository bookRepository;
-  private final UserRepository userRepository;
   private final ReviewMapper reviewMapper;
   private final ApplicationEventPublisher eventPublisher;
 
@@ -82,11 +81,35 @@ public class PopularReviewService {
         )));
   }
 
-  public List<PopularReviewDto> getPopularReviews(Period periodType, LocalDate date) {
-    return popularReviewRepository.findAllByPeriodTypeAndCalculatedDate(periodType, date)
-        .stream()
-        .map(reviewMapper::toPopularDto)
-        .toList();
-  }
+  public CursorPageResponse<PopularReviewDto> getPopularReviews(
+    Period period, String direction, Integer cursor, LocalDateTime after, int limitSize) {
 
+    Limit limitWithNext = Limit.of(limitSize + 1);
+
+    List<PopularReview> results = "DESC".equalsIgnoreCase(direction)
+      ? popularReviewRepository.findPopularReviewsDesc(period, cursor, after, limitWithNext)
+      : popularReviewRepository.findPopularReviewsAsc(period, cursor, after, limitWithNext);
+
+    boolean hasNext = results.size() > limitSize;
+    List<PopularReview> pagedResults = hasNext
+      ? results.subList(0, limitSize)
+      : results;
+
+    List<PopularReviewDto> content = pagedResults.stream()
+      .map(reviewMapper::toPopularDto)
+      .toList();
+
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+    if (!content.isEmpty()) {
+      PopularReview lastItem = pagedResults.get(pagedResults.size() - 1);
+      nextCursor = String.valueOf(lastItem.getRankOrder());
+      nextAfter = lastItem.getCreatedAt();
+    }
+
+    long totalElements = popularReviewRepository.countByPeriodType(period);
+
+    return new CursorPageResponse<>(
+      content, nextCursor, nextAfter, content.size(), totalElements, hasNext);
+  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewService.java
@@ -8,6 +8,7 @@ import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewDto;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewLikeDto;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public interface ReviewService {
@@ -25,5 +26,5 @@ public interface ReviewService {
 
   ReviewLikeDto likeReview(UUID reviewId, UUID requestUserId);
 
-  CursorPageResponse<PopularReviewDto> searchPopularReviews(Period period, String direction, String cursor, String after, int limit);
+  CursorPageResponse<PopularReviewDto> searchPopularReviews(Period period, String direction, String cursor, LocalDateTime after, int limit);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
@@ -1,6 +1,5 @@
 package com.deokhugam.deokhugam_server.domain.review.service;
 
-import static com.deokhugam.deokhugam_server.global.util.DateTimeUtils.parseLocalDateTime;
 
 import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
@@ -171,27 +170,38 @@ public class ReviewServiceImpl implements ReviewService {
 
   @Override
   public CursorPageResponse<PopularReviewDto> searchPopularReviews(Period period, String direction, String cursor,
-      String after, int limit) {
-    Integer cursorRank = (cursor != null && !cursor.isBlank()) ? Integer.parseInt(cursor) : null;
-    LocalDateTime afterLdt = parseLocalDateTime(after);
+    LocalDateTime after, int limit) {
+    Integer cursorInt = (cursor != null && !cursor.isBlank()) ? Integer.parseInt(cursor) : null;
+    Limit limitWithNext = Limit.of(limit + 1);
 
-    List<PopularReview> popularReviews = popularReviewRepository.findPopularReviewsWithPaging(
-        period, direction.toUpperCase(), cursorRank, afterLdt,
-        Limit.of(limit + 1)
-    );
+    List<PopularReview> results = "DESC".equalsIgnoreCase(direction)
+      ? popularReviewRepository.findPopularReviewsDesc(period, cursorInt, after, limitWithNext)
+      : popularReviewRepository.findPopularReviewsAsc(period, cursorInt, after, limitWithNext);
+
+    boolean hasNext = results.size() > limit;
+    List<PopularReview> pagedResults = hasNext ? results.subList(0, limit) : results;
+
+    List<PopularReviewDto> content = pagedResults.stream()
+      .map(reviewMapper::toPopularDto)
+      .toList();
+
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+    if (!content.isEmpty()) {
+      PopularReview lastItem = pagedResults.get(pagedResults.size() - 1);
+      nextCursor = String.valueOf(lastItem.getRankOrder());
+      nextAfter = lastItem.getCreatedAt();
+    }
 
     long totalElements = popularReviewRepository.countByPeriodType(period);
 
-    boolean hasNext = popularReviews.size() > limit;
-    List<PopularReview> content = hasNext ? popularReviews.subList(0, limit) : popularReviews;
-
-    String nextCursor =
-        content.isEmpty() ? null : String.valueOf(content.get(content.size() - 1).getRankOrder());
-    LocalDateTime nextAfter =
-        content.isEmpty() ? null : content.get(content.size() - 1).getCreatedAt();
     return new CursorPageResponse<>(
-        content.stream().map(reviewMapper::toPopularDto).toList(),
-        nextCursor, nextAfter, content.size(), totalElements, hasNext
+      content,
+      nextCursor,
+      nextAfter,
+      content.size(),
+      totalElements,
+      hasNext
     );
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/controller/UserController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/controller/UserController.java
@@ -11,6 +11,7 @@ import com.deokhugam.deokhugam_server.global.type.Period;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -74,7 +75,7 @@ public class UserController {
       @RequestParam(defaultValue = "DAILY") Period period,
       @RequestParam(defaultValue = "ASC") String direction,
       @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) String after,
+      @RequestParam(required = false) LocalDateTime after,
       @RequestParam(defaultValue = "50") int limit
   ) {
     CursorPageResponse<PowerUserDto> response = userService.findPowerUsers(period, direction,

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/dto/response/UserScoreDto.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/dto/response/UserScoreDto.java
@@ -1,0 +1,6 @@
+package com.deokhugam.deokhugam_server.domain.user.dto.response;
+
+import java.util.UUID;
+
+public record UserScoreDto(UUID userId, Double totalScore) {
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/PowerUserRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/PowerUserRepository.java
@@ -3,7 +3,6 @@ package com.deokhugam.deokhugam_server.domain.user.repository;
 import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/PowerUserRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/PowerUserRepository.java
@@ -3,6 +3,7 @@ package com.deokhugam.deokhugam_server.domain.user.repository;
 import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
@@ -14,25 +15,26 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
   @Query("SELECT p FROM PowerUser p " +
     "JOIN FETCH p.user u " +
     "WHERE p.periodType = :period " +
-    "AND (:cursor IS NULL OR p.rankOrder > :cursor) " +
-    "ORDER BY p.rankOrder DESC")
+    "AND (:after IS NULL OR p.createdAt < :after OR (p.createdAt = :after AND p.rankOrder > :cursor)) " +
+    "ORDER BY p.createdAt DESC, p.rankOrder DESC")
   List<PowerUser> findPowerUsersDesc(
     @Param("period") Period period,
     @Param("cursor") Integer cursor,
+    @Param("after") LocalDateTime after,
     Limit limit
   );
 
   @Query("SELECT p FROM PowerUser p " +
     "JOIN FETCH p.user u " +
     "WHERE p.periodType = :period " +
-    "AND (:cursor IS NULL OR p.rankOrder > :cursor) " +
-    "ORDER BY p.rankOrder ASC")
+    "AND (:after IS NULL OR p.createdAt > :after OR (p.createdAt = :after AND p.rankOrder < :cursor)) " +
+    "ORDER BY p.createdAt ASC, p.rankOrder ASC")
   List<PowerUser> findPowerUsersAsc(
     @Param("period") Period period,
     @Param("cursor") Integer cursor,
+    @Param("after") LocalDateTime after,
     Limit limit
   );
-
   List<PowerUser> findAllByPeriodTypeAndCalculatedDate(Period periodType, LocalDate calculatedDate);
 
   long countByPeriodType(Period periodType);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserService.java
@@ -2,6 +2,7 @@ package com.deokhugam.deokhugam_server.domain.user.service;
 
 import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.user.dto.response.UserRankQueryDto;
+import com.deokhugam.deokhugam_server.domain.user.dto.response.UserScoreDto;
 import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.domain.user.repository.PowerUserRepository;
 import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
@@ -10,6 +11,9 @@ import com.deokhugam.deokhugam_server.global.util.PeriodUtil;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,24 +35,21 @@ public class PowerUserService {
     List<UserRankQueryDto> statistics = userRepository.findUserActivityStatistics(startDate,
         endDate);
 
-    List<PowerUser> rankings = statistics.stream()
-        .map(stat -> {
-          Double scoreSum = popularReviewRepository.sumScoreByUserIdAndPeriod(
-              stat.userId(), periodType, endDate).orElse(0.0);
+    Map<UUID, Double> userScoreMap = popularReviewRepository.sumAllUserScoresByPeriod(periodType, endDate)
+      .stream()
+      .collect(Collectors.toMap(UserScoreDto::userId, UserScoreDto::totalScore));
 
-          return PowerUser.builder()
-              .user(userRepository.getReferenceById(stat.userId()))
-              .periodType(periodType)
-              .reviewScoreSum(scoreSum)
-              .likeCount(stat.givenLikeCount())
-              .commentCount(stat.writtenCommentCount())
-              .score((scoreSum * 0.5) + (stat.givenLikeCount() * 0.2) + (stat.writtenCommentCount()
-                  * 0.3))
-              .calculatedDate(endDate)
-              .build();
-        })
-        .sorted(Comparator.comparing(PowerUser::getScore).reversed())
-        .toList();
+    List<PowerUser> rankings = statistics.stream()
+      .map(stat -> {
+        Double scoreSum = userScoreMap.getOrDefault(stat.userId(), 0.0);
+
+        return PowerUser.builder()
+          .user(userRepository.getReferenceById(stat.userId()))
+          .score((scoreSum * 0.5) + (stat.givenLikeCount() * 0.2) + (stat.writtenCommentCount() * 0.3))
+          .build();
+      })
+      .sorted(Comparator.comparing(PowerUser::getScore).reversed())
+      .toList();
 
     for (int i = 0; i < rankings.size(); i++) {
       rankings.get(i).assignRankOrder(i + 1);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserService.java
@@ -45,7 +45,12 @@ public class PowerUserService {
 
         return PowerUser.builder()
           .user(userRepository.getReferenceById(stat.userId()))
-          .score((scoreSum * 0.5) + (stat.givenLikeCount() * 0.2) + (stat.writtenCommentCount() * 0.3))
+          .periodType(periodType)
+          .reviewScoreSum(scoreSum)
+          .likeCount(stat.givenLikeCount())
+          .commentCount(stat.writtenCommentCount())
+          .score((scoreSum * 0.5) + (stat.givenLikeCount() * 0.2) + (stat.writtenCommentCount() * 0.3)) // 최종 점수
+          .calculatedDate(endDate)
           .build();
       })
       .sorted(Comparator.comparing(PowerUser::getScore).reversed())

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserService.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.deokhugam.deokhugam_server.domain.user.dto.response.PowerUserDto;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import com.deokhugam.deokhugam_server.domain.user.dto.response.UserDto;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public interface UserService {
@@ -16,7 +17,7 @@ public interface UserService {
 
   UserDto find( UUID requestUserId, UUID targetUserId);
 
-  CursorPageResponse<PowerUserDto> findPowerUsers(Period period, String direction, String cursor, String after, int limit);
+  CursorPageResponse<PowerUserDto> findPowerUsers(Period period, String direction, String cursor, LocalDateTime after, int limit);
 
   UserDto update( UUID requestUserId, UUID targetUserId, UserUpdateRequest request);
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -8,7 +8,6 @@ import com.deokhugam.deokhugam_server.domain.user.dto.request.UserUpdateRequest;
 import com.deokhugam.deokhugam_server.domain.user.dto.response.PowerUserDto;
 import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.domain.user.repository.PowerUserRepository;
-import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import com.deokhugam.deokhugam_server.domain.user.dto.response.UserDto;
@@ -71,38 +70,38 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public CursorPageResponse<PowerUserDto> findPowerUsers(Period period, String direction,
-      String cursor, String after, int limit) {
-    Integer cursorRank = null;
-    if (cursor != null && !cursor.isBlank()) {
-      try {
-        cursorRank = Integer.parseInt(cursor);
-      } catch (NumberFormatException e) {
-        throw new DeokhugamException(ErrorCode.INVALID_INPUT_VALUE);
-      }
-    }
-    List<PowerUser> powerUsers;
-    if ("DESC".equalsIgnoreCase(direction)) {
-      powerUsers = powerUserRepository.findPowerUsersDesc(
-        period, cursorRank, Limit.of(limit + 1)
-      );
-    } else {
-      powerUsers = powerUserRepository.findPowerUsersAsc(
-        period, cursorRank, Limit.of(limit + 1)
-      );
+      String cursor, LocalDateTime after, int limit) {
+    Integer cursorInt = parseCursor(cursor);
+
+    Limit limitWithNext = Limit.of(limit + 1);
+
+    List<PowerUser> results = "DESC".equalsIgnoreCase(direction)
+      ? powerUserRepository.findPowerUsersDesc(period, cursorInt, after, limitWithNext)
+      : powerUserRepository.findPowerUsersAsc(period, cursorInt, after, limitWithNext);
+
+    boolean hasNext = results.size() > limit;
+    List<PowerUser> pagedResults = hasNext ? results.subList(0, limit) : results;
+
+    List<PowerUserDto> content = pagedResults.stream()
+      .map(userMapper::toPowerUserDto)
+      .toList();
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+    if (!content.isEmpty()) {
+      PowerUser lastItem = pagedResults.get(pagedResults.size() - 1);
+      nextCursor = String.valueOf(lastItem.getRankOrder());
+      nextAfter = lastItem.getCreatedAt();
     }
 
     long totalElements = powerUserRepository.countByPeriodType(period);
 
-    boolean hasNext = powerUsers.size() > limit;
-    List<PowerUser> content = hasNext ? powerUsers.subList(0, limit) : powerUsers;
-
-    String nextCursor =
-        content.isEmpty() ? null : String.valueOf(content.get(content.size() - 1).getRankOrder());
-    LocalDateTime nextAfter =
-        content.isEmpty() ? null : content.get(content.size() - 1).getCreatedAt();
     return new CursorPageResponse<>(
-        content.stream().map(userMapper::toPowerUserDto).toList(),
-        nextCursor, nextAfter, content.size(), totalElements, hasNext
+      content,
+      nextCursor,
+      nextAfter,
+      content.size(),
+      totalElements,
+      hasNext
     );
   }
 
@@ -149,5 +148,14 @@ public class UserServiceImpl implements UserService {
       throw new DeokhugamException(HANDLE_ACCESS_DENIED);
     }
   }
-
+  private Integer parseCursor(String cursor) {
+    if (cursor == null || cursor.isBlank()) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(cursor);
+    } catch (NumberFormatException e) {
+      throw new DeokhugamException(INVALID_INPUT_VALUE);
+    }
+  }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,6 @@
 package com.deokhugam.deokhugam_server.domain.user.service;
 
 import static com.deokhugam.deokhugam_server.global.exception.ErrorCode.*;
-import static com.deokhugam.deokhugam_server.global.util.DateTimeUtils.parseLocalDateTime;
 
 import com.deokhugam.deokhugam_server.domain.user.dto.request.UserLoginRequest;
 import com.deokhugam.deokhugam_server.domain.user.dto.request.UserRegisterRequest;

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -616,7 +617,6 @@ class BookServiceImplTest {
     Period period = Period.DAILY;
     String direction = "DESC";
     String cursor = null;
-    String after = null;
     int limit = 10;
 
     PopularBook popularBook = mock(PopularBook.class);
@@ -635,9 +635,8 @@ class BookServiceImplTest {
       LocalDateTime.now()
     );
 
-    when(popularBookRepository.findPopularBooksWithPaging(
+    when(popularBookRepository.findPopularBooksDesc(
       eq(period),
-      eq("DESC"),
       nullable(Integer.class),
       nullable(LocalDateTime.class),
       any(Limit.class)
@@ -647,7 +646,7 @@ class BookServiceImplTest {
     when(bookMapper.toPopularDto(popularBook)).thenReturn(dto);
 
     CursorPageResponse<PopularBookDto> result =
-      bookService.searchPopularBooks(period, direction, cursor, after, limit);
+      bookService.searchPopularBooks(period, direction, cursor, LocalDateTime.now(), limit);
 
     assertNotNull(result);
     assertEquals(1, result.content().size());
@@ -660,7 +659,6 @@ class BookServiceImplTest {
   void searchPopularBooks_success_hasNext() {
     Period period = Period.DAILY;
     String direction = "DESC";
-    int limit = 1;
 
     PopularBook first = mock(PopularBook.class);
     PopularBook second = mock(PopularBook.class);
@@ -684,9 +682,8 @@ class BookServiceImplTest {
       firstCreatedAt
     );
 
-    when(popularBookRepository.findPopularBooksWithPaging(
+    when(popularBookRepository.findPopularBooksDesc(
       eq(period),
-      eq("DESC"),
       nullable(Integer.class),
       nullable(LocalDateTime.class),
       any(Limit.class)
@@ -696,13 +693,13 @@ class BookServiceImplTest {
     when(bookMapper.toPopularDto(first)).thenReturn(firstDto);
 
     CursorPageResponse<PopularBookDto> result =
-      bookService.searchPopularBooks(period, direction, null, null, limit);
+      bookService.searchPopularBooks(period, direction, null, null, 1);
 
     assertNotNull(result);
     assertEquals(1, result.content().size());
     assertEquals(2L, result.totalElements());
     assertEquals("1", result.nextCursor());
     assertEquals(firstCreatedAt, result.nextAfter());
-    assertEquals(true, result.hasNext());
+    assertTrue(result.hasNext());
   }
 }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/PopularReviewServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
 import com.deokhugam.deokhugam_server.domain.review.dto.response.ReviewRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.review.entity.PopularReview;
 import com.deokhugam.deokhugam_server.domain.review.entity.Review;
@@ -13,7 +12,6 @@ import com.deokhugam.deokhugam_server.domain.review.mapper.ReviewMapper;
 import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
 import com.deokhugam.deokhugam_server.domain.user.entity.User;
-import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,8 +34,6 @@ class PopularReviewServiceTest {
 
   @Mock private ReviewRepository reviewRepository;
   @Mock private PopularReviewRepository popularReviewRepository;
-  @Mock private BookRepository bookRepository;
-  @Mock private UserRepository userRepository;
   @Mock private ReviewMapper reviewMapper;
   @Mock private ApplicationEventPublisher eventPublisher;
   private Map<UUID, Review> reviewMap;
@@ -46,8 +42,7 @@ class PopularReviewServiceTest {
   void setUp() {
     closeable = MockitoAnnotations.openMocks(this);
     popularReviewService = new PopularReviewService(
-        reviewRepository, popularReviewRepository, bookRepository,
-        userRepository, reviewMapper, eventPublisher
+        reviewRepository, popularReviewRepository, reviewMapper, eventPublisher
     );
     reviewMap = new HashMap<>();
   }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -45,7 +44,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Limit;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -173,11 +171,11 @@ class ReviewServiceImplTest {
       PopularReview pr = PopularReview.builder().review(review).rankOrder(1).build();
       ReflectionTestUtils.setField(pr, "createdAt", LocalDateTime.now());
 
-      given(popularReviewRepository.findPopularReviewsWithPaging(any(), anyString(), any(), any(), any(Limit.class)))
+      given(popularReviewRepository.findPopularReviewsDesc(any(), any(), any(), any()))
         .willReturn(List.of(pr));
       given(popularReviewRepository.countByPeriodType(any())).willReturn(1L);
 
-      CursorPageResponse<PopularReviewDto> result = reviewService.searchPopularReviews(Period.DAILY, "DESC", "1", "2026-04-21T00:00:00Z", 10);
+      CursorPageResponse<PopularReviewDto> result = reviewService.searchPopularReviews(Period.DAILY, "DESC", null, null, 10);
       assertThat(result.content()).isNotEmpty();
       verify(reviewMapper, atLeastOnce()).toPopularDto(any());
     }

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.user.dto.response.UserRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.domain.user.entity.User;
@@ -15,7 +14,6 @@ import com.deokhugam.deokhugam_server.domain.user.repository.PowerUserRepository
 import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import com.deokhugam.deokhugam_server.global.type.Period;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,9 +33,6 @@ class PowerUserServiceTest {
   @Mock
   private PowerUserRepository powerUserRepository;
 
-  @Mock
-  private PopularReviewRepository popularReviewRepository;
-
   @InjectMocks
   private PowerUserService powerUserService;
 
@@ -56,7 +51,6 @@ class PowerUserServiceTest {
     UserRankQueryDto user2Stat = new UserRankQueryDto(user2Id, 0L, 50L, 100L);
 
     given(userRepository.findUserActivityStatistics(any(), any())).willReturn(List.of(user1Stat, user2Stat));
-    given(popularReviewRepository.sumScoreByUserIdAndPeriod(any(), any(), any())).willReturn(Optional.of(0.0));
 
     given(userRepository.getReferenceById(user1Id)).willReturn(User.builder().id(user1Id).build());
     given(userRepository.getReferenceById(user2Id)).willReturn(User.builder().id(user2Id).build());

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/PowerUserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.deokhugam.deokhugam_server.domain.review.repository.PopularReviewRepository;
 import com.deokhugam.deokhugam_server.domain.user.dto.response.UserRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
 import com.deokhugam.deokhugam_server.domain.user.entity.User;
@@ -35,6 +36,9 @@ class PowerUserServiceTest {
 
   @InjectMocks
   private PowerUserService powerUserService;
+
+  @Mock
+  private PopularReviewRepository popularReviewRepository;
 
   @Captor
   private ArgumentCaptor<List<PowerUser>> listCaptor;

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
@@ -275,7 +275,7 @@ class UserServiceTest {
     ReflectionTestUtils.setField(user1, "createdAt", LocalDateTime.now());
     ReflectionTestUtils.setField(user2, "createdAt", LocalDateTime.now());
 
-    given(powerUserRepository.findPowerUsersDesc(eq(Period.MONTHLY), any(), any(Limit.class)))
+    given(powerUserRepository.findPowerUsersDesc(eq(Period.MONTHLY), any(), any(), any(Limit.class)))
       .willReturn(List.of(user1, user2));
 
     given(powerUserRepository.countByPeriodType(Period.MONTHLY)).willReturn(10L);
@@ -292,7 +292,7 @@ class UserServiceTest {
     assertThat(result.nextCursor()).isEqualTo("1");
     assertThat(result.totalElements()).isEqualTo(10L);
 
-    verify(powerUserRepository).findPowerUsersDesc(eq(Period.MONTHLY), any(), any(Limit.class));
+    verify(powerUserRepository).findPowerUsersDesc(eq(Period.MONTHLY), any(),any(), any(Limit.class));
     verify(userMapper, atLeastOnce()).toPowerUserDto(any());
   }
 
@@ -309,5 +309,5 @@ class UserServiceTest {
         .isInstanceOf(DeokhugamException.class)
         .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
 
-    verify(powerUserRepository, never()).findPowerUsersDesc(any(), any(), any());  }
+    verify(powerUserRepository, never()).findPowerUsersDesc(any(), any(),any(), any());  }
 }


### PR DESCRIPTION

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion: https://www.notion.so/Dashboard-repository-3506e443c28880e887b6c8906de84520?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

### ✨ 기능 추가 / 구현
- **도메인별 인기 콘텐츠 조회**: 도서, 리뷰, 유저(파워 유저) 도메인 전체에 대해 커서 기반 페이징이 적용된 인기 콘텐츠 조회 기능을 구현하였습니다.
- **공통 페이징 로직 적용**: `Limit(limit + 1)` 방식을 사용하여 다음 페이지 존재 여부(`hasNext`)를 판단하는 로직을 서비스 레이어에 일관되게 적용하였습니다.

### ♻️ 리팩토링
- **컨트롤러 파라미터 타입 변경**: API의 일관성과 타입 안정성을 위해 `after` 파라미터의 타입을 `String`에서 `LocalDateTime`으로 변경하였습니다.
- **리포지토리 쿼리 분리 및 최적화**: 
    - 기존의 동적 정렬 방식에서 발생할 수 있는 복잡도를 줄이기 위해 `findPopularBooksDesc`와 `findPopularBooksAsc`와 같이 정렬 방향별로 쿼리 메서드를 분리하였습니다.
    - `@Query` 내에 `JOIN FETCH`를 적용하여 N+1 문제를 방지하고 조회 성능을 최적화하였습니다.
- **파워 유저 계산 방식 개선**: 사용자별 점수 합계를 일괄 조회하는 방식으로 쿼리를 리팩토링하여 데이터베이스 부하를 줄였습니다.
- **전 계층 코드 동기화**: 위 변경 사항에 맞춰 관련 컨트롤러, 서비스, 리포지토리 및 테스트 코드를 전면 수정하였습니다.

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
### 1. API 파라미터 타입 변경
- 도서, 리뷰, 유저 컨트롤러의 `after` 파라미터 타입을 기존 `String`에서 `LocalDateTime`으로 변경하였습니다.
- 이는 API 전반의 타입 일관성을 유지하고, 서버 내부에서의 불필요한 파싱 로직을 줄여 타입 안정성을 확보하기 위함입니다.

### 2. 도메인별 영향 범위 및 수정 내용
- **대상**: 도서(Book), 리뷰(Review) 도메인의 일부 컨트롤러, 리포지토리, 서비스 및 테스트 코드
- **주요 수정**: 대시보드(인기 도서, 인기 리뷰) 조회를 위한 정렬 쿼리를 방향별(`Desc`, `Asc`)로 분리하고 관련 로직을 동기화하였습니다.
- **안내**: 해당 수정은 대시보드 기능 고도화를 위해 필요한 최소한의 범위 내에서 진행되었습니다. 타 도메인의 핵심 비즈니스 로직에는 영향을 주지 않도록 작업하였으니 리뷰 시 참고 부탁드립니다.

### 3. 테스트 코드 보완
- 위 변경 사항에 맞춰 기존의 도서 및 리뷰 관련 테스트 코드가 정상적으로 동작하도록 파라미터와 호출 방식을 모두 최신화하였습니다.