### PR TITLE
[BE-101] feat: 배치 테스트작성 및 관련 설정 업데이트

### DIFF
--- a/deokhugam/build.gradle
+++ b/deokhugam/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+  testImplementation 'org.springframework.batch:spring-batch-test'
 	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/batch/PopularBookBatchTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/batch/PopularBookBatchTest.java
@@ -1,0 +1,32 @@
+package com.deokhugam.deokhugam_server.domain.book.batch;
+
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.domain.book.service.PopularBookService;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PopularBookBatchTest {
+
+  @InjectMocks
+  private PopularBookBatch popularBookBatch;
+
+  @Mock
+  private PopularBookService popularBookService;
+
+  @Test
+  @DisplayName("성공: 데일리 배치 실행 시 도서 랭킹 서비스의 DAILY 산출 로직을 호출한다")
+  void executeDaily_Success() {
+    // when
+    popularBookBatch.executeDaily();
+
+    // then
+    verify(popularBookService).calculateAndSaveRanks(Period.DAILY);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/batch/PopularReviewBatchTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/batch/PopularReviewBatchTest.java
@@ -1,0 +1,32 @@
+package com.deokhugam.deokhugam_server.domain.review.batch;
+
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.domain.review.service.PopularReviewService;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PopularReviewBatchTest {
+
+  @InjectMocks
+  private PopularReviewBatch popularReviewBatch;
+
+  @Mock
+  private PopularReviewService popularReviewService;
+
+  @Test
+  @DisplayName("성공: 데일리 배치 실행 시 인기 리뷰 서비스의 산출 로직을 호출한다")
+  void executeDaily_Success() {
+    // when
+    popularReviewBatch.executeDaily();
+
+    // then
+    verify(popularReviewService).calculateAndSaveReviewRanks(Period.DAILY);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/batch/PowerUserBatchTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/batch/PowerUserBatchTest.java
@@ -1,0 +1,30 @@
+package com.deokhugam.deokhugam_server.domain.user.batch;
+
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.domain.user.service.PowerUserService;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PowerUserBatchTest {
+
+  @InjectMocks
+  private PowerUserBatch powerUserBatch;
+
+  @Mock
+  private PowerUserService powerUserService;
+
+  @Test
+  @DisplayName("성공: 데일리 배치 실행 시 파워 유저 서비스의 산출 로직을 호출한다")
+  void executeDaily_Success() {
+    // when
+    powerUserBatch.executeDaily();
+    verify(powerUserService).calculateAndSavePowerUserRanks(Period.DAILY);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/batch/UserHardDeleteBatchTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/batch/UserHardDeleteBatchTest.java
@@ -1,0 +1,60 @@
+package com.deokhugam.deokhugam_server.domain.user.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserHardDeleteBatchTest {
+
+  @InjectMocks
+  private UserHardDeleteBatch userHardDeleteBatch;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("성공: 삭제 대상 유저가 존재하면 deleteAllInBatch를 호출한다")
+  void cleanupOldDeletedUsers_WhenTargetsExist() {
+    // given
+    User mockUser = User.builder().build();
+    List<User> targets = List.of(mockUser);
+
+    // threshold가 LocalDateTime.now() 기준이라 any()로 매칭해야 에러가 안 납니다.
+    when(userRepository.findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class)))
+      .thenReturn(targets);
+
+    // when
+    userHardDeleteBatch.cleanupOldDeletedUsers();
+
+    // then
+    verify(userRepository).deleteAllInBatch(targets);
+  }
+
+  @Test
+  @DisplayName("성공: 삭제 대상 유저가 없으면 deleteAllInBatch를 호출하지 않는다")
+  void cleanupOldDeletedUsers_WhenNoTargets() {
+    // given
+    when(userRepository.findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class)))
+      .thenReturn(Collections.emptyList());
+
+    // when
+    userHardDeleteBatch.cleanupOldDeletedUsers();
+
+    // then
+    verify(userRepository, never()).deleteAllInBatch(any());
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/batch/RankingBatchConfigTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/batch/RankingBatchConfigTest.java
@@ -1,0 +1,53 @@
+package com.deokhugam.deokhugam_server.global.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.global.type.Period;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBatchTest
+@SpringBootTest
+@ActiveProfiles("test")
+public class RankingBatchConfigTest {
+
+  @Autowired(required = false)
+  private JobLauncherTestUtils jobLauncherTestUtils;
+
+  @Autowired
+  @Qualifier("rankingJob")
+  private Job rankingJob;
+
+  @BeforeEach
+  void setUp() {
+    jobLauncherTestUtils.setJob(rankingJob);
+  }
+
+  @Test
+  @DisplayName("성공: 랭킹 배치 Job이 성공적으로 완료된다")
+  void rankingJob_Execution_Success() throws Exception {
+    // given
+    JobParameters jobParameters = new JobParametersBuilder()
+      .addString("period", Period.DAILY.name())
+      .addLong("requestedAt", System.currentTimeMillis())
+      .toJobParameters();
+
+    // when
+    JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+    // then
+    assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+  }
+}


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/batch-unit-test-3506e443c28880b5aee0c382e5f2410d?source=copy_link

## 🛠️ 작업 내용
### ✨ 기능 추가 / 구현
- 배치 도메인 테스트 코드 단위 테스트 구현

### ⚙️ 설정 변경
- **`build.gradle` 수정**
  - 배치 설정 테스트 및 커버리지 측정을 위해 `spring-batch-test` 의존성 추가 확인.

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 모든 배치 테스트를 가벼운 `Mockito` 단위 테스트로 구현하였습니다.
- `RankingBatchConfig`는 설정 파일 특성상 스프링 컨텍스트가 로드되어야 커버리지가 측정되므로, 이 부분만 `JobLauncherTestUtils`를 사용하는 가벼운 통합 테스트 형식을 유지했습니다.