### PR TITLE
Fix: 도서 등록 썸네일 처리 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClient.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClient.java
@@ -7,6 +7,7 @@ import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -59,8 +60,28 @@ public class NaverBookClient implements BookInfoClient {
       clean(item.publisher()),
       parsePublishedDate(item.pubdate()),
       item.normalizedIsbn(),
-      item.image()
+      encodeImageAsBase64(item.image())
     );
+  }
+
+  private String encodeImageAsBase64(String imageUrl) {
+    if (imageUrl == null || imageUrl.isBlank()) {
+      return null;
+    }
+
+    try {
+      byte[] imageBytes = restClientBuilder.build()
+        .get()
+        .uri(imageUrl)
+        .retrieve()
+        .body(byte[].class);
+
+      return imageBytes == null || imageBytes.length == 0
+        ? null
+        : Base64.getEncoder().encodeToString(imageBytes);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   private LocalDate parsePublishedDate(String value) {

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/controller/BookController.java
@@ -7,10 +7,16 @@ import com.deokhugam.deokhugam_server.domain.book.dto.response.BookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.NaverBookDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.PopularBookDto;
 import com.deokhugam.deokhugam_server.domain.book.service.BookService;
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
+import jakarta.validation.Validator;
 import java.time.LocalDateTime;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +27,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,12 +39,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class BookController {
 
   private final BookService bookService;
+  private final ObjectMapper objectMapper;
+  private final Validator validator;
 
   @PostMapping(consumes = "multipart/form-data")
   public ResponseEntity<BookDto> createBook(
-          @Valid @ModelAttribute BookCreateRequest request,
-          @RequestParam(required = false) MultipartFile thumbnailImage
+          @RequestPart(value = "bookData", required = false) String bookData,
+          @ModelAttribute BookCreateRequest formData,
+          @RequestPart(required = false) MultipartFile thumbnailImage
   ) {
+    BookCreateRequest request = resolveRequest(bookData, formData, BookCreateRequest.class);
     BookDto response = bookService.createBook(request, thumbnailImage);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
@@ -71,9 +82,11 @@ public class BookController {
   @PatchMapping(value = "/{bookId}", consumes = "multipart/form-data")
   public ResponseEntity<BookDto> updateBook(
           @PathVariable UUID bookId,
-          @Valid @ModelAttribute BookUpdateRequest request,
-          @RequestParam(required = false) MultipartFile thumbnailImage
+          @RequestPart(value = "bookData", required = false) String bookData,
+          @ModelAttribute BookUpdateRequest formData,
+          @RequestPart(required = false) MultipartFile thumbnailImage
   ) {
+    BookUpdateRequest request = resolveRequest(bookData, formData, BookUpdateRequest.class);
     BookDto response = bookService.updateBook(bookId, request, thumbnailImage);
     return ResponseEntity.ok(response);
   }
@@ -102,5 +115,30 @@ public class BookController {
       period, direction, cursor, after, limit
     );
     return ResponseEntity.ok(popularBooks);
+  }
+
+  private <T> T resolveRequest(String bookData, T formData, Class<T> requestType) {
+    T request = hasText(bookData) ? readBookData(bookData, requestType) : formData;
+    validateRequest(request);
+    return request;
+  }
+
+  private <T> T readBookData(String bookData, Class<T> requestType) {
+    try {
+      return objectMapper.readValue(bookData, requestType);
+    } catch (JsonProcessingException e) {
+      throw new DeokhugamException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+  }
+
+  private <T> void validateRequest(T request) {
+    Set<?> violations = validator.validate(request);
+    if (!violations.isEmpty()) {
+      throw new DeokhugamException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -19,6 +19,7 @@ import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.deokhugam.deokhugam_server.global.util.S3Util;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -49,12 +50,14 @@ public class BookServiceImpl implements BookService {
   private final PopularBookRepository popularBookRepository;
   private final TextExtractionClient textExtractionClient;
   private final BookInfoClient bookInfoClient;
+  private final S3Util s3Util;
 
   @Override
   @Transactional
   public BookDto createBook(BookCreateRequest request, MultipartFile thumbnailImage) {
     String normalizedIsbn = normalizeIsbn(request.isbn());
     validateDuplicateIsbn(normalizedIsbn);
+    String thumbnailUrl = uploadThumbnailImage(thumbnailImage);
 
     Book book = new Book(
       request.title().trim(),
@@ -62,7 +65,7 @@ public class BookServiceImpl implements BookService {
       normalizedIsbn,
       normalizeText(request.publisher()),
       normalizeText(request.description()),
-      null,
+      thumbnailUrl,
       request.publishedDate()
     );
 
@@ -133,13 +136,14 @@ public class BookServiceImpl implements BookService {
   public BookDto updateBook(UUID bookId, BookUpdateRequest request, MultipartFile thumbnailImage) {
     Book book = bookRepository.findByIdAndIsDeletedFalse(bookId)
       .orElseThrow(() -> new DeokhugamException(ErrorCode.BOOK_NOT_FOUND));
+    String thumbnailUrl = uploadThumbnailImage(thumbnailImage);
 
     book.update(
       normalizeText(request.title()),
       normalizeText(request.author()),
       normalizeText(request.publisher()),
       normalizeText(request.description()),
-      null,
+      thumbnailUrl,
       request.publishedDate()
     );
 
@@ -226,6 +230,19 @@ public class BookServiceImpl implements BookService {
       throw new DeokhugamException(ErrorCode.INVALID_FILE);
     }
 
+    validateImageContentType(image);
+  }
+
+  private String uploadThumbnailImage(MultipartFile image) {
+    if (image == null || image.isEmpty()) {
+      return null;
+    }
+
+    validateImageContentType(image);
+    return s3Util.upload(image, "books");
+  }
+
+  private void validateImageContentType(MultipartFile image) {
     String contentType = image.getContentType();
     if (contentType == null || !contentType.startsWith("image/")) {
       throw new DeokhugamException(ErrorCode.INVALID_FILE_TYPE);

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClientTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/client/NaverBookClientTest.java
@@ -14,6 +14,7 @@ import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,9 @@ class NaverBookClientTest {
         .andExpect(header("X-Naver-Client-Id", "client-id"))
         .andExpect(header("X-Naver-Client-Secret", "client-secret"))
         .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+    server.expect(requestTo("https://image.example/book.jpg"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("image-bytes".getBytes(), MediaType.IMAGE_JPEG));
 
     // when
     NaverBookDto result = client.searchByIsbn(isbn);
@@ -75,7 +79,9 @@ class NaverBookClientTest {
     assertThat(result.description()).isEqualTo("좋은 코드를 위한 설명");
     assertThat(result.publishedDate()).isEqualTo(LocalDate.of(2024, 1, 31));
     assertThat(result.isbn()).isEqualTo(isbn);
-    assertThat(result.thumbnailImage()).isEqualTo("https://image.example/book.jpg");
+    assertThat(result.thumbnailImage()).isEqualTo(
+        Base64.getEncoder().encodeToString("image-bytes".getBytes())
+    );
     server.verify();
   }
 

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/controller/BookControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/controller/BookControllerTest.java
@@ -93,6 +93,58 @@ class BookControllerTest {
   }
 
   @Test
+  @DisplayName("도서 등록 성공 - bookData JSON 파트")
+  void createBook_success_withBookDataJsonPart() throws Exception {
+    UUID bookId = UUID.randomUUID();
+    LocalDate publishedDate = LocalDate.of(2024, 1, 1);
+    LocalDateTime now = LocalDateTime.of(2026, 4, 23, 10, 0);
+    MockMultipartFile bookData = new MockMultipartFile(
+      "bookData",
+      "",
+      "application/json",
+      """
+          {
+            "title": "클린 코드",
+            "author": "로버트 마틴",
+            "isbn": "978-89-1234-567-8",
+            "publisher": "인사이트",
+            "description": "설명",
+            "publishedDate": "2024-01-01"
+          }
+          """.getBytes()
+    );
+    MockMultipartFile thumbnailImage = new MockMultipartFile(
+      "thumbnailImage",
+      "thumbnail.png",
+      "image/png",
+      "dummy-image".getBytes()
+    );
+    BookDto response = new BookDto(
+      bookId,
+      "클린 코드",
+      "로버트 마틴",
+      "설명",
+      "인사이트",
+      publishedDate,
+      "9788912345678",
+      "https://image.test/thumbnail.png",
+      0,
+      0.0,
+      now,
+      now
+    );
+
+    when(bookService.createBook(any(), any())).thenReturn(response);
+
+    mockMvc.perform(multipart("/api/books")
+        .file(bookData)
+        .file(thumbnailImage))
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.id").value(bookId.toString()))
+      .andExpect(jsonPath("$.thumbnailUrl").value("https://image.test/thumbnail.png"));
+  }
+
+  @Test
   @DisplayName("도서 목록 조회 성공")
   void getBooks_success() throws Exception {
     UUID bookId = UUID.randomUUID();

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
@@ -33,6 +33,7 @@ import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import com.deokhugam.deokhugam_server.global.response.CursorPageResponse;
 import com.deokhugam.deokhugam_server.global.type.Period;
+import com.deokhugam.deokhugam_server.global.util.S3Util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -64,6 +65,9 @@ class BookServiceImplTest {
 
   @Mock
   private BookInfoClient bookInfoClient;
+
+  @Mock
+  private S3Util s3Util;
 
   @InjectMocks
   private BookServiceImpl bookService;
@@ -128,6 +132,72 @@ class BookServiceImplTest {
     assertEquals(expectedDto.title(), result.title());
     assertEquals(expectedDto.isbn(), result.isbn());
     verify(bookRepository, times(1)).save(any(Book.class));
+  }
+
+  @Test
+  @DisplayName("도서 생성 성공 - 썸네일 이미지를 S3에 업로드한다")
+  void createBook_success_withThumbnailImage() {
+    UUID bookId = UUID.randomUUID();
+    LocalDate publishedDate = LocalDate.of(2024, 1, 1);
+    LocalDateTime now = LocalDateTime.now();
+    String thumbnailUrl = "https://s3.test/books/thumbnail.png";
+
+    BookCreateRequest request = new BookCreateRequest(
+      "클린 코드",
+      "로버트 마틴",
+      "978-89-1234-567-8",
+      "인사이트",
+      "설명",
+      publishedDate
+    );
+    MockMultipartFile thumbnailImage = new MockMultipartFile(
+      "thumbnailImage",
+      "thumbnail.png",
+      "image/png",
+      "dummy-image".getBytes()
+    );
+    Book savedBook = mock(Book.class);
+    BookSearchQueryDto queryDto = new BookSearchQueryDto(
+      bookId,
+      "클린 코드",
+      "로버트 마틴",
+      "설명",
+      "인사이트",
+      publishedDate,
+      "9788912345678",
+      thumbnailUrl,
+      0L,
+      0.0,
+      now,
+      now
+    );
+    BookDto expectedDto = new BookDto(
+      bookId,
+      "클린 코드",
+      "로버트 마틴",
+      "설명",
+      "인사이트",
+      publishedDate,
+      "9788912345678",
+      thumbnailUrl,
+      0,
+      0.0,
+      now,
+      now
+    );
+
+    when(bookRepository.existsByIsbn("9788912345678")).thenReturn(false);
+    when(s3Util.upload(thumbnailImage, "books")).thenReturn(thumbnailUrl);
+    when(bookRepository.save(any(Book.class))).thenReturn(savedBook);
+    when(savedBook.getId()).thenReturn(bookId);
+    when(bookRepository.findBookDetail(bookId)).thenReturn(queryDto);
+    when(bookMapper.toDto(queryDto)).thenReturn(expectedDto);
+
+    BookDto result = bookService.createBook(request, thumbnailImage);
+
+    assertEquals(thumbnailUrl, result.thumbnailUrl());
+    verify(s3Util).upload(thumbnailImage, "books");
+    verify(bookRepository).save(any(Book.class));
   }
 
   @Test


### PR DESCRIPTION
## 🛠️ 작업 내용

### 🐛 버그 수정
- bookData JSON multipart 파싱 지원
- 기존 평면 form-data 방식도 계속 지원
- 도서 등록/수정 시 thumbnailImage를 S3에 업로드하고 thumbnailUrl로 저장
- 네이버 이미지 URL을 서버에서 base64로 변환해 thumbnailImage로 응답
- 관련 컨트롤러/서비스/클라이언트 테스트 추가

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항


