### PR TITLE
[BE-107] Fix: S3 썸네일 표시 URL 처리 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/config/S3Config.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -16,6 +17,14 @@ public class S3Config {
   @Bean
   public S3Client s3Client() {
     return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+
+  @Bean
+  public S3Presigner s3Presigner() {
+    return S3Presigner.builder()
         .region(Region.of(region))
         .credentialsProvider(DefaultCredentialsProvider.create())
         .build();

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/mapper/StaticImagePathMapper.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/mapper/StaticImagePathMapper.java
@@ -1,12 +1,17 @@
 package com.deokhugam.deokhugam_server.global.mapper;
 
+import com.deokhugam.deokhugam_server.global.util.S3Util;
+import lombok.RequiredArgsConstructor;
 import org.mapstruct.Named;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class StaticImagePathMapper {
 
   private static final String IMAGES_PREFIX = "images/";
+
+  private final S3Util s3Util;
 
   @Named("normalizeStaticImagePath")
   public String normalizeStaticImagePath(String thumbnailUrl) {
@@ -16,7 +21,7 @@ public class StaticImagePathMapper {
 
     String normalized = thumbnailUrl.trim();
     if (normalized.contains("://") || normalized.startsWith("//")) {
-      return normalized;
+      return s3Util.toPresignedUrlIfS3Url(normalized);
     }
 
     while (normalized.startsWith("/")) {

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/util/S3Util.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/util/S3Util.java
@@ -3,6 +3,7 @@ package com.deokhugam.deokhugam_server.global.util;
 import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
 import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +13,10 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Slf4j
 @Component
@@ -20,12 +24,16 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 public class S3Util {
 
   private final S3Client s3Client;
+  private final S3Presigner s3Presigner;
 
   @Value("${cloud.aws.s3.bucket}")
   private String bucket;
 
   @Value("${cloud.aws.region.static}")
   private String region;
+
+  @Value("${cloud.aws.s3.presigned-url-expiration:3600}")
+  private long presignedUrlExpirationSeconds;
 
   /**
    * MultipartFile을 S3에 업로드하고 퍼블릭 URL을 반환합니다.
@@ -71,8 +79,30 @@ public class S3Util {
     }
   }
 
+  public String toPresignedUrlIfS3Url(String fileUrl) {
+    if (fileUrl == null || fileUrl.isBlank() || !isManagedS3Url(fileUrl)) {
+      return fileUrl;
+    }
+
+    String key = extractKeyFromUrl(fileUrl);
+    GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+        .bucket(bucket)
+        .key(key)
+        .build();
+    GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+        .signatureDuration(Duration.ofSeconds(presignedUrlExpirationSeconds))
+        .getObjectRequest(getObjectRequest)
+        .build();
+
+    return s3Presigner.presignGetObject(presignRequest).url().toString();
+  }
+
   private String buildUrl(String key) {
     return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+  }
+
+  private boolean isManagedS3Url(String url) {
+    return url.startsWith("https://" + bucket + ".s3." + region + ".amazonaws.com/");
   }
 
   private String extractKeyFromUrl(String url) {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/mapper/StaticImagePathMapperTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/mapper/StaticImagePathMapperTest.java
@@ -1,13 +1,17 @@
 package com.deokhugam.deokhugam_server.global.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import com.deokhugam.deokhugam_server.global.util.S3Util;
 
 class StaticImagePathMapperTest {
 
-  private final StaticImagePathMapper mapper = new StaticImagePathMapper();
+  private final S3Util s3Util = Mockito.mock(S3Util.class);
+  private final StaticImagePathMapper mapper = new StaticImagePathMapper(s3Util);
 
   @Test
   @DisplayName("정적 이미지 경로는 프론트가 /images prefix를 붙일 수 있도록 상대 경로로 변환한다")
@@ -21,11 +25,14 @@ class StaticImagePathMapperTest {
   }
 
   @Test
-  @DisplayName("S3 같은 외부 URL은 그대로 유지한다")
+  @DisplayName("외부 URL은 S3Util을 통해 표시 가능한 URL로 변환한다")
   void normalizeStaticImagePath_externalUrl() {
     String url = "https://bucket.s3.ap-northeast-2.amazonaws.com/books/image.png";
+    String presignedUrl = url + "?X-Amz-Signature=signature";
 
-    assertThat(mapper.normalizeStaticImagePath(url)).isEqualTo(url);
+    when(s3Util.toPresignedUrlIfS3Url(url)).thenReturn(presignedUrl);
+
+    assertThat(mapper.normalizeStaticImagePath(url)).isEqualTo(presignedUrl);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/S3-URL-3516e443c28880a6b493c7ae4b3ca558?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- S3Presigner bean 추가
- S3Util.toPresignedUrlIfS3Url() 추가

### ♻️ 리팩토링
- S3 관리 URL이면 응답 시 presigned URL로 변환
- mapper 테스트 갱신

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 도서 등록 시 s3 비공개 접근으로 인한 차단을 우회

