### PR TITLE
[BE-111] 파워 유저 랭킹 집계 관련 오류 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryCustomImpl.java
@@ -48,7 +48,9 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
         commentsCount
       ))
       .from(user)
-      .where(user.isDeleted.isFalse())
+      .where(user.isDeleted.isFalse(),
+        reviewsCount.gt(0L).or(likesCount.gt(0L)).or(commentsCount.gt(0L))
+        )
       .fetch();
   }
 }


### PR DESCRIPTION

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion: https://www.notion.so/3516e443c288801aa13de48974a68a21?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

### 🐛 버그 수정
- 파워 유저 랭킹 집계 시 활동 내역이 없는 유저 필터링 추가
  - `UserRepositoryCustomImpl`의 `findUserActivityStatistics` 쿼리 수정
  - 기간 내 리뷰, 좋아요, 댓글 활동 중 하나라도 있는 유저만 집계하도록 필터링 로직 강화
  - 활동 점수가 0점인 유저가 랭킹 리스트에 불필요하게 노출되는 문제 해결

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->
- 로컬 개발 환경에서 배치 스케줄러 주기를 조정하여 일간(DAILY), 주간(WEEKLY), 월간(MONTHLY), 전체(ALL_TIME) 랭킹 정합성 테스트를 완료했습니다.
- 활동 내역이 없는 유저가 0점으로 랭킹에 진입하지 않도록 쿼리 레벨에서 필터링을 추가하여 데이터 신뢰도를 높였습니다.
