### PR TITLE
[BE-115] Fix: S3 로그 업로드 롤링 타이밍 보정

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd deokhugam
 
 ### S3 날짜별 로그 적재
 
-애플리케이션 파일 로그는 `/app/logs`에 생성되고, 스케줄러가 매일 `00:10 Asia/Seoul`에 전날 로그를 S3에 업로드합니다.
+애플리케이션 파일 로그는 `/app/logs`에 생성되고, 스케줄러가 매일 `01:00 Asia/Seoul`에 전날 로그를 S3에 업로드합니다.
 
 - 로컬 로그 파일: `/app/logs/deokhugam.yyyy-MM-dd.log`
 - S3 적재 경로: `app/yyyy/MM/dd/deokhugam.yyyy-MM-dd.log`

--- a/deokhugam/docs/AWS_DEPLOYMENT.md
+++ b/deokhugam/docs/AWS_DEPLOYMENT.md
@@ -129,7 +129,7 @@ RUN mkdir -p /app/logs && chown -R appuser:appgroup /app
 
 ### S3 업로드 스케줄
 
-`DailyLogUploadScheduler`가 매일 `00:10 Asia/Seoul`에 전날 로그 파일을 S3로 업로드합니다.
+`DailyLogUploadScheduler`가 매일 `01:00 Asia/Seoul`에 전날 로그 파일을 S3로 업로드합니다. 배치 시작 로그를 먼저 남겨 Logback 날짜 롤링을 유도한 뒤, 전날 로그 파일을 업로드합니다.
 
 업로드 경로:
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadScheduler.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadScheduler.java
@@ -5,11 +5,13 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class DailyLogUploadScheduler {
 
@@ -31,9 +33,10 @@ public class DailyLogUploadScheduler {
     this.clock = clock;
   }
 
-  @Scheduled(cron = "${deokhugam.log.s3.upload-cron:0 10 0 * * *}", zone = "Asia/Seoul")
+  @Scheduled(cron = "${deokhugam.log.s3.upload-cron:0 0 1 * * *}", zone = "Asia/Seoul")
   public void uploadYesterdayLog() {
     LocalDate targetDate = LocalDate.now(clock).minusDays(1);
+    log.info("Daily log S3 upload started. targetDate={}", targetDate);
     Path targetFile = Path.of(localPath, "deokhugam.%s.log".formatted(targetDate));
 
     dailyLogS3Uploader.upload(targetDate, targetFile);

--- a/deokhugam/src/main/resources/application.yml
+++ b/deokhugam/src/main/resources/application.yml
@@ -32,7 +32,7 @@ deokhugam:
       bucket: ${S3_LOG_BUCKET:}
       prefix: ${S3_LOG_PREFIX:app}
       local-path: ${LOG_FILE_PATH:./logs}
-      upload-cron: ${S3_LOG_UPLOAD_CRON:0 10 0 * * *}
+      upload-cron: ${S3_LOG_UPLOAD_CRON:0 0 1 * * *}
       delete-after-upload: ${S3_LOG_DELETE_AFTER_UPLOAD:false}
 
 management:

--- a/task-definition.json
+++ b/task-definition.json
@@ -52,6 +52,10 @@
           "value": "false"
         },
         {
+          "name": "S3_LOG_UPLOAD_CRON",
+          "value": "0 0 1 * * *"
+        },
+        {
           "name": "SPRING_PROFILES_ACTIVE",
           "value": "dev"
         }


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/S3-3526e443c2888052aee6d32f0ba51971?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- S3 로그 업로드 배치가 날짜별 로그 파일을 찾지 못해 업로드 건너뛰는 문제를 수정
- Logback 날짜 롤링이 업로드 배치보다 늦게 발생할 수 있는 문제 보완

### ✨ 기능 추가 / 구현
- S3 로그 업로드 시작 시 로그 먼저 남겨 Logback 날짜별 파일 롤링 유도하도록 구현
- ECS Task Definition에 `S3_LOG_UPLOAD_CRON` 환경변수 추가 로그 업로드 시간 조정

### ⚙️ 설정 변경
- S3 로그 업로드 기본 실행 시간을 `00:10`에서 `01:00 Asia/Seoul`로 변경
- README와 AWS 배포 문서의 S3 로그 업로드 스케줄 설명 갱신

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test --tests com.deokhugam.deokhugam_server.global.scheduler.DailyLogUploadSchedulerTest`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 기존에는 날짜 변경 직후 Logback 롤링 파일이 아직 생성되지 않은 상태에서 S3 업로드 배치가 먼저 실행
- 배포 후 다음날 `01:00 Asia/Seoul` 이후 `s3://deokhugam-logs-297904/app/yyyy/MM/dd/` 경로에서 업로드 여부를 확인
