### PR TITLE
[BE-118] Test: global 커버리지 보강

### DIFF
--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/NotificationCleanupSchedulerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/NotificationCleanupSchedulerTest.java
@@ -1,0 +1,58 @@
+package com.deokhugam.deokhugam_server.global.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCleanupSchedulerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job notificationCleanupJob;
+
+  @Test
+  @DisplayName("성공: 알림 정리 배치를 실행한다")
+  void runNotificationCleanup_LaunchesJob() throws Exception {
+    NotificationCleanupScheduler scheduler = new NotificationCleanupScheduler(
+        jobLauncher,
+        notificationCleanupJob
+    );
+
+    scheduler.runNotificationCleanup();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getLong("requestedAt")).isNotNull();
+  }
+
+  @Test
+  @DisplayName("실패: 알림 정리 배치 실행 예외는 스케줄러 밖으로 전파하지 않는다")
+  void runNotificationCleanup_WhenJobLaunchFails_DoesNotThrow() throws Exception {
+    NotificationCleanupScheduler scheduler = new NotificationCleanupScheduler(
+        jobLauncher,
+        notificationCleanupJob
+    );
+    doThrow(new JobExecutionAlreadyRunningException("already running"))
+        .when(jobLauncher)
+        .run(any(Job.class), any(JobParameters.class));
+
+    scheduler.runNotificationCleanup();
+
+    verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/RankingSchedulerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/RankingSchedulerTest.java
@@ -1,0 +1,83 @@
+package com.deokhugam.deokhugam_server.global.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+
+@ExtendWith(MockitoExtension.class)
+class RankingSchedulerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job rankingJob;
+
+  @Test
+  @DisplayName("성공: 일간과 전체 랭킹 배치를 함께 실행한다")
+  void runDailyAndAllTimeRanking_LaunchesDailyAndAllTimeJobs() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+
+    scheduler.runDailyAndAllTimeRanking();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher, times(2)).run(any(Job.class), captor.capture());
+    List<String> periods = captor.getAllValues().stream()
+        .map(params -> params.getString("period"))
+        .toList();
+    assertThat(periods).containsExactly(Period.DAILY.name(), Period.ALL_TIME.name());
+  }
+
+  @Test
+  @DisplayName("성공: 주간 랭킹 배치를 실행한다")
+  void runWeeklyRanking_LaunchesWeeklyJob() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+
+    scheduler.runWeeklyRanking();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getString("period")).isEqualTo(Period.WEEKLY.name());
+  }
+
+  @Test
+  @DisplayName("성공: 월간 랭킹 배치를 실행한다")
+  void runMonthlyRanking_LaunchesMonthlyJob() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+
+    scheduler.runMonthlyRanking();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getString("period")).isEqualTo(Period.MONTHLY.name());
+  }
+
+  @Test
+  @DisplayName("실패: 랭킹 배치 실행 예외는 스케줄러 밖으로 전파하지 않는다")
+  void runWeeklyRanking_WhenJobLaunchFails_DoesNotThrow() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+    doThrow(new JobExecutionAlreadyRunningException("already running"))
+        .when(jobLauncher)
+        .run(any(Job.class), any(JobParameters.class));
+
+    scheduler.runWeeklyRanking();
+
+    verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/type/PeriodTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/type/PeriodTest.java
@@ -1,0 +1,41 @@
+package com.deokhugam.deokhugam_server.global.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PeriodTest {
+
+  @Test
+  @DisplayName("성공: 대소문자와 무관하게 기간 값을 변환한다")
+  void from_ValidValue() {
+    assertThat(Period.from("daily")).isEqualTo(Period.DAILY);
+    assertThat(Period.from("WEEKLY")).isEqualTo(Period.WEEKLY);
+    assertThat(Period.from("monthly")).isEqualTo(Period.MONTHLY);
+    assertThat(Period.from("all_time")).isEqualTo(Period.ALL_TIME);
+  }
+
+  @Test
+  @DisplayName("실패: null 또는 blank 기간 값이면 예외를 던진다")
+  void from_NullOrBlank_ThrowsException() {
+    assertInvalidPeriod(null);
+    assertInvalidPeriod(" ");
+  }
+
+  @Test
+  @DisplayName("실패: 지원하지 않는 기간 값이면 예외를 던진다")
+  void from_InvalidValue_ThrowsException() {
+    assertInvalidPeriod("yearly");
+  }
+
+  private void assertInvalidPeriod(String value) {
+    assertThatThrownBy(() -> Period.from(value))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_PERIOD);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/S3UtilTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/S3UtilTest.java
@@ -1,0 +1,168 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3UtilTest {
+
+  private static final String BUCKET = "deokhugam-storage";
+  private static final String REGION = "ap-northeast-2";
+
+  @Mock
+  private S3Client s3Client;
+
+  @Mock
+  private S3Presigner s3Presigner;
+
+  private S3Util s3Util;
+
+  @BeforeEach
+  void setUp() {
+    s3Util = new S3Util(s3Client, s3Presigner);
+    ReflectionTestUtils.setField(s3Util, "bucket", BUCKET);
+    ReflectionTestUtils.setField(s3Util, "region", REGION);
+    ReflectionTestUtils.setField(s3Util, "presignedUrlExpirationSeconds", 3600L);
+  }
+
+  @Test
+  @DisplayName("성공: 파일을 S3에 업로드하고 관리 URL을 반환한다")
+  void upload_Success() {
+    MockMultipartFile file = new MockMultipartFile(
+        "file",
+        "cover.png",
+        "image/png",
+        "image".getBytes()
+    );
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    String result = s3Util.upload(file, "books");
+
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3Client).putObject(captor.capture(), any(RequestBody.class));
+    PutObjectRequest request = captor.getValue();
+    assertThat(request.bucket()).isEqualTo(BUCKET);
+    assertThat(request.key()).startsWith("books/").endsWith("_cover.png");
+    assertThat(request.contentType()).isEqualTo("image/png");
+    assertThat(request.contentLength()).isEqualTo(file.getSize());
+    assertThat(result).startsWith("https://deokhugam-storage.s3.ap-northeast-2.amazonaws.com/books/");
+    assertThat(result).endsWith("_cover.png");
+  }
+
+  @Test
+  @DisplayName("실패: 파일 업로드 중 예외가 발생하면 S3 업로드 예외를 던진다")
+  void upload_WhenFails_ThrowsException() throws Exception {
+    MockMultipartFile file = new FailingMultipartFile();
+
+    assertThatThrownBy(() -> s3Util.upload(file, "books"))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.S3_UPLOAD_FAILED);
+  }
+
+  @Test
+  @DisplayName("성공: null 또는 blank URL 삭제는 건너뛴다")
+  void delete_NullOrBlank_SkipsDelete() {
+    s3Util.delete(null);
+    s3Util.delete(" ");
+
+    verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+  }
+
+  @Test
+  @DisplayName("성공: S3 URL에서 key를 추출해 객체를 삭제한다")
+  void delete_Success() {
+    String fileUrl = managedUrl("books/cover.png");
+    when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3Util.delete(fileUrl);
+
+    ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+    verify(s3Client).deleteObject(captor.capture());
+    assertThat(captor.getValue().bucket()).isEqualTo(BUCKET);
+    assertThat(captor.getValue().key()).isEqualTo("books/cover.png");
+  }
+
+  @Test
+  @DisplayName("실패: S3 형식이 아닌 URL 삭제 시 삭제 예외를 던진다")
+  void delete_InvalidUrl_ThrowsException() {
+    assertThatThrownBy(() -> s3Util.delete("https://example.com/image.png"))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.S3_DELETE_FAILED);
+  }
+
+  @Test
+  @DisplayName("성공: 관리 대상 S3 URL이면 presigned URL로 변환한다")
+  void toPresignedUrlIfS3Url_ManagedUrl_ReturnsPresignedUrl() throws Exception {
+    String fileUrl = managedUrl("books/cover.png");
+    PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
+    when(presignedRequest.url())
+        .thenReturn(new URL("https://presigned.example.com/books/cover.png"));
+    when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class)))
+        .thenReturn(presignedRequest);
+
+    String result = s3Util.toPresignedUrlIfS3Url(fileUrl);
+
+    assertThat(result).isEqualTo("https://presigned.example.com/books/cover.png");
+    verify(s3Presigner).presignGetObject(any(GetObjectPresignRequest.class));
+  }
+
+  @Test
+  @DisplayName("성공: 관리 대상이 아닌 URL은 그대로 반환한다")
+  void toPresignedUrlIfS3Url_NotManaged_ReturnsOriginal() {
+    assertThat(s3Util.toPresignedUrlIfS3Url(null)).isNull();
+    assertThat(s3Util.toPresignedUrlIfS3Url(" ")).isEqualTo(" ");
+    assertThat(s3Util.toPresignedUrlIfS3Url("https://example.com/image.png"))
+        .isEqualTo("https://example.com/image.png");
+
+    verify(s3Presigner, never()).presignGetObject(any(GetObjectPresignRequest.class));
+  }
+
+  private String managedUrl(String key) {
+    return "https://%s.s3.%s.amazonaws.com/%s".formatted(BUCKET, REGION, key);
+  }
+
+  private static class FailingMultipartFile extends MockMultipartFile {
+
+    FailingMultipartFile() {
+      super("file", "cover.png", "image/png", new byte[0]);
+    }
+
+    @Override
+    public java.io.InputStream getInputStream() throws IOException {
+      throw new IOException("read failed");
+    }
+  }
+}


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/3526e443c28880329588f75f9818c8a5?source=copy_link

## 🛠️ 작업 내용

### ✨ 기능 추가 / 구현
- global 영역 테스트 코드를 추가해 전체 테스트 커버리지 보강
- `Period.from()`의 정상 변환, null/blank/invalid 입력 예외 케이스 검증
- `RankingScheduler`의 일간/전체/주간/월간 배치 실행 흐름과 Job 실행 실패 시 예외 전파 방지 동작 검증
- `NotificationCleanupScheduler`의 알림 정리 배치 실행 흐름과 Job 실행 실패 시 예외 전파 방지 동작 검증
- `S3Util`의 파일 업로드, 삭제, presigned URL 변환, 예외 케이스 검증

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인
- [x] 관련 단위 테스트 작성 및 통과 확인
- [x] 전체 테스트 및 커버리지 검증 통과 확인
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 전체 커버리지 검증 결과:
  - Instruction coverage: `84.95%`
  - Line coverage: `84.58%`
- global 주요 패키지 커버리지:
  - `global.scheduler`: `100.0%`
  - `global.type`: `100.0%`
  - `global.util`: `98.0%`
