### PR TITLE
[BE-119] 인기 리뷰 순위 관련 오류 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
@@ -147,20 +147,23 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
     return queryFactory
       .select(Projections.constructor(
         BookRankQueryDto.class,
-        review.book.id,
+        book.id,
         review.id.countDistinct(),
         review.rating.avg().coalesce(0.0)
       ))
-      .from(review)
-      .where(
+      .from(book)
+      .leftJoin(review).on(
+        review.book.eq(book),
         review.isDeleted.isFalse(),
-        review.book.isDeleted.isFalse(),
-        review.createdAt.between(
-          startDate.atStartOfDay(),
-          endDate.atTime(LocalTime.MAX)
-        )
+        review.createdAt.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX))
       )
-      .groupBy(review.book.id)
+      .where(book.isDeleted.isFalse())
+      .groupBy(book.id)
+      .having(review.id.countDistinct().gt(0))
+      .orderBy(
+        review.id.countDistinct().desc(),
+        review.rating.avg().desc()
+      )
       .fetch();
   }
 
@@ -188,8 +191,8 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
         buildPopularBookCursorCondition(direction, cursor, after)
       )
       .orderBy(
-        buildPopularBookRankOrderSpecifier(direction),
-        buildPopularBookIdOrderSpecifier(direction)
+        popularBook.rankOrder.asc(),
+        popularBook.id.asc()
       )
       .limit(limit + 1L)
       .fetch();

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepositoryImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class PopularReviewRepositoryImpl implements PopularReviewRepositoryCustom {
+
   private final JPAQueryFactory queryFactory;
 
   @Override
@@ -27,9 +28,7 @@ public class PopularReviewRepositoryImpl implements PopularReviewRepositoryCusto
         popularReview.calculatedDate.eq(latestDate),
         cursorCondition(popularReview, cursor, direction)
       )
-      .orderBy(direction.equalsIgnoreCase("ASC") ?
-          popularReview.rankOrder.asc() : popularReview.rankOrder.desc()
-      )
+      .orderBy(popularReview.rankOrder.asc())
       .limit(limit + 1)
       .fetch();
   }
@@ -37,11 +36,6 @@ public class PopularReviewRepositoryImpl implements PopularReviewRepositoryCusto
   private BooleanExpression cursorCondition(QPopularReview pr, Integer cursor, String direction) {
     if (cursor == null)
       return null;
-
-    if (direction.equalsIgnoreCase("ASC")) {
-      return pr.rankOrder.gt(cursor);
-    } else {
-      return pr.rankOrder.lt(cursor);
-    }
+    return pr.rankOrder.gt(cursor);
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImpl.java
@@ -85,10 +85,12 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             comment.id.countDistinct()
         ))
         .from(review)
-        .leftJoin(reviewLike).on(reviewLike.review.eq(review))
-        .leftJoin(comment).on(comment.review.eq(review))
-        .where(review.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX)))
+        .leftJoin(reviewLike).on(reviewLike.review.eq(review)
+          .and(reviewLike.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX))))
+        .leftJoin(comment).on(comment.review.eq(review)
+          .and(comment.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX))))
         .groupBy(review.id)
+        .having(reviewLike.id.countDistinct().gt(0).or(comment.id.countDistinct().gt(0)))
         .fetch();
   }
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryCustomImpl.java
@@ -48,7 +48,9 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
         commentsCount
       ))
       .from(user)
-      .where(user.isDeleted.isFalse())
+      .where(user.isDeleted.isFalse(),
+        reviewsCount.gt(0L).or(likesCount.gt(0L)).or(commentsCount.gt(0L))
+        )
       .fetch();
   }
 }


### PR DESCRIPTION

## 🔗 Notion Task 링크
- Notion:  https://www.notion.so/3526e443c28880958062e755721b1910?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- 인기 도서 및 리뷰 랭킹 조회 시 정렬 순서가 거꾸로(내림차순) 나오던 현상 수정
- Swagger의 `direction` 예시값(DESC)과 백엔드 `rankOrder` 정렬 로직(ASC) 간의 충돌 해결
- 과거에 작성된 리뷰가 최근 활동(좋아요/댓글)이 있음에도 랭킹에서 누락되던 로직 수정

### ✨ 기능 추가 / 구현
- 인기 리뷰 집계 시 리뷰 작성일 제한을 제거하고, 지정된 기간 내의 '좋아요/댓글' 활동을 기준으로 집계하도록 변경
- 인기 도서 통계 쿼리에 `leftJoin ... on` 절을 사용하여 기간 내 활동 기반 집계 효율성 개선
- 랭킹 데이터 전용 커서 페이지네이션(Cursor-based Pagination) 및 정렬 방향(ASC) 강제 고정 로직 구현

### ♻️ 리팩토링
- `PopularReviewRepositoryImpl` 및 `BookRepositoryCustomImpl` 내 랭킹 전용 조회 쿼리 최적화
- 일반 검색 정렬 로직에 영향을 주지 않도록 랭킹 전용 정렬 Specifier 분리 적용

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] API 동작 확인 (Swagger를 통한 기간별/정렬별 인기 리뷰 및 도서 데이터 노출 확인)
- [x] 수동 배치 실행을 통한 일간/주간/월간/전체 랭킹 데이터 생성 및 정합성 검증

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] Mapstruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 랭킹 데이터는 등수(`rankOrder`)가 낮을수록(1등) 상단에 노출되어야 하므로, 프론트엔드의 `direction` 파라미터와 관계없이 백엔드 쿼리에서 `ASC`로 정렬을 고정하였습니다.