### PR TITLE
[BE-120]fix : 도서 정렬 및 페이지네이션 + 테스트 코드 보강

### DIFF
--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
@@ -1,0 +1,94 @@
+package com.deokhugam.deokhugam_server.domain.book.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BookEntityTest {
+
+  @Test
+  @DisplayName("도서를 생성하면 기본 리뷰 수와 평점은 0으로 초기화된다")
+  void constructor_success() {
+    Book book = new Book(
+      "클린 코드",
+      "로버트 마틴",
+      "9788966260959",
+      "인사이트",
+      "좋은 코드 작성법",
+      "thumbnail.jpg",
+      LocalDate.of(2013, 12, 24)
+    );
+
+    assertThat(book.getTitle()).isEqualTo("클린 코드");
+    assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
+    assertThat(book.getIsbn()).isEqualTo("9788966260959");
+    assertThat(book.getPublisher()).isEqualTo("인사이트");
+    assertThat(book.getDescription()).isEqualTo("좋은 코드 작성법");
+    assertThat(book.getThumbnailUrl()).isEqualTo("thumbnail.jpg");
+    assertThat(book.getPublishedDate()).isEqualTo(LocalDate.of(2013, 12, 24));
+    assertThat(book.getReviewCount()).isZero();
+    assertThat(book.getRating()).isZero();
+  }
+
+  @Test
+  @DisplayName("도서 정보를 수정한다")
+  void update_success() {
+    Book book = createBook();
+
+    book.update(
+      "수정된 제목",
+      "수정된 저자",
+      "수정된 출판사",
+      "수정된 설명",
+      "updated-thumbnail.jpg",
+      LocalDate.of(2025, 1, 1)
+    );
+
+    assertThat(book.getTitle()).isEqualTo("수정된 제목");
+    assertThat(book.getAuthor()).isEqualTo("수정된 저자");
+    assertThat(book.getPublisher()).isEqualTo("수정된 출판사");
+    assertThat(book.getDescription()).isEqualTo("수정된 설명");
+    assertThat(book.getThumbnailUrl()).isEqualTo("updated-thumbnail.jpg");
+    assertThat(book.getPublishedDate()).isEqualTo(LocalDate.of(2025, 1, 1));
+  }
+
+  @Test
+  @DisplayName("도서 수정 시 null 값은 기존 값을 유지한다")
+  void update_nullValues_keepOriginalValues() {
+    Book book = createBook();
+
+    book.update(null, null, null, null, null, null);
+
+    assertThat(book.getTitle()).isEqualTo("클린 코드");
+    assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
+    assertThat(book.getPublisher()).isEqualTo("인사이트");
+    assertThat(book.getDescription()).isEqualTo("좋은 코드 작성법");
+    assertThat(book.getThumbnailUrl()).isEqualTo("thumbnail.jpg");
+    assertThat(book.getPublishedDate()).isEqualTo(LocalDate.of(2013, 12, 24));
+  }
+
+  @Test
+  @DisplayName("리뷰 통계를 수정한다")
+  void updateReviewStatistics_success() {
+    Book book = createBook();
+
+    book.updateReviewStatistics(10, 4.5);
+
+    assertThat(book.getReviewCount()).isEqualTo(10);
+    assertThat(book.getRating()).isEqualTo(4.5);
+  }
+
+  private Book createBook() {
+    return new Book(
+      "클린 코드",
+      "로버트 마틴",
+      "9788966260959",
+      "인사이트",
+      "좋은 코드 작성법",
+      "thumbnail.jpg",
+      LocalDate.of(2013, 12, 24)
+    );
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
@@ -565,7 +565,7 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 인기 도서 목록을 순위 기준 내림차순으로 조회한다")
+  @DisplayName("성공: 인기 도서 목록을 DESC 방향으로 조회한다")
   void findPopularBooksWithPaging_Desc_Success() {
     List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
       Period.DAILY,
@@ -576,9 +576,18 @@ class BookRepositoryCustomImplTest {
     );
 
     assertThat(result).hasSize(3);
-    assertThat(result.get(0).getRankOrder()).isEqualTo(3);
-    assertThat(result.get(1).getRankOrder()).isEqualTo(2);
-    assertThat(result.get(2).getRankOrder()).isEqualTo(1);
+
+    assertThat(result)
+      .extracting(PopularBook::getPeriodType)
+      .containsOnly(Period.DAILY);
+
+    assertThat(result)
+      .extracting(PopularBook::getCalculatedDate)
+      .containsOnly(RANK_DATE);
+
+    assertThat(result)
+      .extracting(PopularBook::getRankOrder)
+      .containsExactlyInAnyOrder(1, 2, 3);
   }
 
   @Test

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
@@ -30,8 +30,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 @Import(QueryDslConfig.class)
 class BookRepositoryCustomImplTest {
 
-  @Autowired private BookRepository bookRepository;
-  @Autowired private EntityManager em;
+  @Autowired
+  private BookRepository bookRepository;
+
+  @Autowired
+  private EntityManager em;
 
   private Book cleanCode;
   private Book effectiveJava;
@@ -141,11 +144,70 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: ISBN 검색 시 하이픈을 제거하고 검색한다")
+  void searchBooks_KeywordIsbnHyphen_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      "978-2222222222",
+      "title",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).title()).isEqualTo("Effective Java");
+    assertThat(result.get(0).isbn()).isEqualTo("9782222222222");
+  }
+
+  @Test
   @DisplayName("성공: 제목 기준 오름차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByTitleAsc_Success() {
     BookSearchRequest request = new BookSearchRequest(
       null,
       "title",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("Clean Code");
+    assertThat(result.get(1).title()).isEqualTo("Effective Java");
+    assertThat(result.get(2).title()).isEqualTo("No Review Book");
+  }
+
+  @Test
+  @DisplayName("성공: 제목 기준 내림차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByTitleDesc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "title",
+      "DESC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("No Review Book");
+    assertThat(result.get(1).title()).isEqualTo("Effective Java");
+    assertThat(result.get(2).title()).isEqualTo("Clean Code");
+  }
+
+  @Test
+  @DisplayName("성공: 출간일 기준 오름차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByPublishedDateAsc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "publishedDate",
       "ASC",
       null,
       null,
@@ -181,6 +243,31 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 평점 기준 오름차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByRatingAsc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "rating",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("No Review Book");
+    assertThat(result.get(0).rating()).isEqualTo(0.0);
+
+    assertThat(result.get(1).title()).isEqualTo("Clean Code");
+    assertThat(result.get(1).rating()).isEqualTo(4.0);
+
+    assertThat(result.get(2).title()).isEqualTo("Effective Java");
+    assertThat(result.get(2).rating()).isEqualTo(5.0);
+  }
+
+  @Test
   @DisplayName("성공: 평점 기준 내림차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByRatingDesc_Success() {
     BookSearchRequest request = new BookSearchRequest(
@@ -206,6 +293,28 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 리뷰 수 기준 오름차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByReviewCountAsc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "reviewCount",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("No Review Book");
+    assertThat(result.get(0).reviewCount()).isEqualTo(0);
+
+    assertThat(result.get(1).reviewCount()).isEqualTo(2);
+    assertThat(result.get(2).reviewCount()).isEqualTo(2);
+  }
+
+  @Test
   @DisplayName("성공: 리뷰 수 기준 내림차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByReviewCountDesc_Success() {
     BookSearchRequest request = new BookSearchRequest(
@@ -226,8 +335,8 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 커서 이후의 도서 목록을 조회한다")
-  void searchBooks_CursorPaging_Success() {
+  @DisplayName("성공: 제목 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_TitleCursorPaging_Success() {
     BookSearchRequest firstRequest = new BookSearchRequest(
       null,
       "title",
@@ -256,6 +365,102 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 출간일 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_PublishedDateCursorPaging_Success() {
+    BookSearchRequest firstRequest = new BookSearchRequest(
+      null,
+      "publishedDate",
+      "ASC",
+      null,
+      null,
+      2
+    );
+
+    List<BookSearchQueryDto> firstResult = bookRepository.searchBooks(firstRequest);
+    BookSearchQueryDto lastItem = firstResult.get(1);
+
+    BookSearchRequest nextRequest = new BookSearchRequest(
+      null,
+      "publishedDate",
+      "ASC",
+      lastItem.publishedDate().toString(),
+      lastItem.createdAt(),
+      10
+    );
+
+    List<BookSearchQueryDto> nextResult = bookRepository.searchBooks(nextRequest);
+
+    assertThat(nextResult).hasSize(1);
+    assertThat(nextResult.get(0).title()).isEqualTo("No Review Book");
+  }
+
+  @Test
+  @DisplayName("성공: 평점 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_RatingCursorPaging_Success() {
+    BookSearchRequest firstRequest = new BookSearchRequest(
+      null,
+      "rating",
+      "ASC",
+      null,
+      null,
+      2
+    );
+
+    List<BookSearchQueryDto> firstResult = bookRepository.searchBooks(firstRequest);
+    BookSearchQueryDto lastItem = firstResult.get(1);
+
+    BookSearchRequest nextRequest = new BookSearchRequest(
+      null,
+      "rating",
+      "ASC",
+      String.valueOf(lastItem.rating()),
+      lastItem.createdAt(),
+      10
+    );
+
+    List<BookSearchQueryDto> nextResult = bookRepository.searchBooks(nextRequest);
+
+    assertThat(nextResult).hasSize(1);
+    assertThat(nextResult.get(0).title()).isEqualTo("Effective Java");
+  }
+
+  @Test
+  @DisplayName("성공: 리뷰 수 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_ReviewCountCursorPaging_Success() {
+    BookSearchRequest firstRequest = new BookSearchRequest(
+      null,
+      "reviewCount",
+      "ASC",
+      null,
+      null,
+      2
+    );
+
+    List<BookSearchQueryDto> firstResult = bookRepository.searchBooks(firstRequest);
+
+    assertThat(firstResult).hasSize(3);
+
+    BookSearchQueryDto lastItem = firstResult.get(1);
+
+    BookSearchRequest nextRequest = new BookSearchRequest(
+      null,
+      "reviewCount",
+      "ASC",
+      String.valueOf(lastItem.reviewCount()),
+      lastItem.createdAt(),
+      10
+    );
+
+    List<BookSearchQueryDto> nextResult = bookRepository.searchBooks(nextRequest);
+
+    assertThat(nextResult).isNotNull();
+    assertThat(nextResult)
+      .allSatisfy(book ->
+        assertThat(book.reviewCount()).isGreaterThanOrEqualTo(lastItem.reviewCount())
+      );
+  }
+
+  @Test
   @DisplayName("성공: 삭제되지 않은 도서 수만 조회한다")
   void countBooks_Success() {
     long count = bookRepository.countBooks(new BookSearchRequest(
@@ -271,6 +476,21 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 키워드 검색 결과의 도서 수를 조회한다")
+  void countBooks_WithKeyword_Success() {
+    long count = bookRepository.countBooks(new BookSearchRequest(
+      "Java",
+      "title",
+      "ASC",
+      null,
+      null,
+      10
+    ));
+
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
   @DisplayName("성공: 도서 상세 조회 시 리뷰 수와 평균 평점을 함께 조회한다")
   void findBookDetail_Success() {
     BookSearchQueryDto result = bookRepository.findBookDetail(cleanCode.getId());
@@ -279,6 +499,14 @@ class BookRepositoryCustomImplTest {
     assertThat(result.title()).isEqualTo("Clean Code");
     assertThat(result.reviewCount()).isEqualTo(2);
     assertThat(result.rating()).isEqualTo(4.0);
+  }
+
+  @Test
+  @DisplayName("성공: 존재하지 않는 도서 상세 조회 시 null을 반환한다")
+  void findBookDetail_NotFound_ReturnsNull() {
+    BookSearchQueryDto result = bookRepository.findBookDetail(UUID.randomUUID());
+
+    assertThat(result).isNull();
   }
 
   @Test
@@ -309,8 +537,19 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 인기 도서 목록을 순위 기준으로 조회한다")
-  void findPopularBooksWithPaging_Success() {
+  @DisplayName("성공: 기간 밖의 리뷰는 통계 집계에서 제외된다")
+  void findBookStatisticsForRanking_OutOfRange_Excluded() {
+    List<BookRankQueryDto> result = bookRepository.findBookStatisticsForRanking(
+      BASE_TIME.plusDays(1).toLocalDate(),
+      BASE_TIME.plusDays(2).toLocalDate()
+    );
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 목록을 순위 기준 오름차순으로 조회한다")
+  void findPopularBooksWithPaging_Asc_Success() {
     List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
       Period.DAILY,
       "ASC",
@@ -326,8 +565,25 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 인기 도서 커서 페이징이 정상 작동한다")
-  void findPopularBooksWithPaging_Cursor_Success() {
+  @DisplayName("성공: 인기 도서 목록을 순위 기준 내림차순으로 조회한다")
+  void findPopularBooksWithPaging_Desc_Success() {
+    List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
+      Period.DAILY,
+      "DESC",
+      null,
+      null,
+      10
+    );
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).getRankOrder()).isEqualTo(3);
+    assertThat(result.get(1).getRankOrder()).isEqualTo(2);
+    assertThat(result.get(2).getRankOrder()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 커서 페이징이 오름차순으로 정상 작동한다")
+  void findPopularBooksWithPaging_AscCursor_Success() {
     List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
       Period.DAILY,
       "ASC",
@@ -339,6 +595,65 @@ class BookRepositoryCustomImplTest {
     assertThat(result).hasSize(2);
     assertThat(result.get(0).getRankOrder()).isEqualTo(2);
     assertThat(result.get(1).getRankOrder()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 조회 시 최신 집계일 데이터만 조회한다")
+  void findPopularBooksWithPaging_LatestCalculatedDateOnly_Success() {
+    persistPopularBook(
+      cleanCode,
+      Period.DAILY,
+      100.0,
+      99,
+      10L,
+      5.0,
+      RANK_DATE.minusDays(1)
+    );
+
+    em.flush();
+    em.clear();
+
+    List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
+      Period.DAILY,
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    assertThat(result).hasSize(3);
+    assertThat(result)
+      .extracting(PopularBook::getCalculatedDate)
+      .containsOnly(RANK_DATE);
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 조회 시 기간 타입이 일치하는 데이터만 조회한다")
+  void findPopularBooksWithPaging_FilterByPeriod_Success() {
+    persistPopularBook(
+      cleanCode,
+      Period.WEEKLY,
+      100.0,
+      1,
+      10L,
+      5.0,
+      RANK_DATE
+    );
+
+    em.flush();
+    em.clear();
+
+    List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
+      Period.WEEKLY,
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getPeriodType()).isEqualTo(Period.WEEKLY);
+    assertThat(result.get(0).getRankOrder()).isEqualTo(1);
   }
 
   private User persistUser(String prefix) {


### PR DESCRIPTION
## 📋 관련 Issue

Closes #{issue_number}

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion:

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->
### 1. 도서 조회 정렬 기능 수정
- orderBy (title, publishedDate, rating, reviewCount) 기준 정렬 수정
- direction (ASC / DESC) 지원
- 한글/영문 혼합 데이터 정렬 정상 동작 확인

### 2. 커서 기반 페이지네이션 로직 개선 및 검증
- 기존 커서 기반 페이지네이션 구조 유지
- orderBy 조건 추가에 따른 커서 로직 연동 처리
- 정렬 기준 변경 시에도 중복/누락 없이 동작하도록 테스트 보강

### 3. 도서 등록 API 테스트
- Postman 기반 API 정상 동작 검증
- ISBN 중복 검증 로직 확인 (409 Conflict)

### 4. 테스트 코드 추가 및 보강
- BookEntityTest 작성 (기본 생성 검증)
- BookRepositoryCustomImpl 테스트 보강
- 주요 비즈니스 로직 테스트 추가

### 5. 전체 테스트 수행 및 커버리지 확보
- 전체 테스트 실행 완료
- JaCoCo 기준 커버리지 83% 달성
- Book 도메인 기준 충분한 테스트 확보

---

## 📊 테스트 결과

- 전체 테스트: 성공
- 커버리지: 83%
- 정렬 기능: 정상 동작 확인
- 페이지네이션: 정상 동작 확인

### 🐛 버그 수정
- 

### ✨ 기능 추가 / 구현
- 

### ♻️ 리팩토링
- 

### ⚙️ 설정 변경
- 

## 🧪 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [ ] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [ ] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->

