### PR TITLE
[BE-RELEASE] 운영 배포 반영 v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd deokhugam
 
 ### S3 날짜별 로그 적재
 
-애플리케이션 파일 로그는 `/app/logs`에 생성되고, 스케줄러가 매일 `00:10 Asia/Seoul`에 전날 로그를 S3에 업로드합니다.
+애플리케이션 파일 로그는 `/app/logs`에 생성되고, 스케줄러가 매일 `01:00 Asia/Seoul`에 전날 로그를 S3에 업로드합니다.
 
 - 로컬 로그 파일: `/app/logs/deokhugam.yyyy-MM-dd.log`
 - S3 적재 경로: `app/yyyy/MM/dd/deokhugam.yyyy-MM-dd.log`

--- a/deokhugam/docs/AWS_DEPLOYMENT.md
+++ b/deokhugam/docs/AWS_DEPLOYMENT.md
@@ -129,7 +129,7 @@ RUN mkdir -p /app/logs && chown -R appuser:appgroup /app
 
 ### S3 업로드 스케줄
 
-`DailyLogUploadScheduler`가 매일 `00:10 Asia/Seoul`에 전날 로그 파일을 S3로 업로드합니다.
+`DailyLogUploadScheduler`가 매일 `01:00 Asia/Seoul`에 전날 로그 파일을 S3로 업로드합니다. 배치 시작 로그를 먼저 남겨 Logback 날짜 롤링을 유도한 뒤, 전날 로그 파일을 업로드합니다.
 
 업로드 경로:
 
@@ -142,6 +142,19 @@ s3://<log-bucket>/app/yyyy/MM/dd/deokhugam.yyyy-MM-dd.log
 | Prefix | Transition | Expiration |
 | --- | --- | --- |
 | `app/` | 30일 후 Standard-IA 또는 Glacier 계층 | 90일 또는 프로젝트 제출 이후 삭제 |
+
+## 운영 배치 스케줄
+
+모든 운영 배치는 `Asia/Seoul` 시간대를 명시합니다.
+
+| 작업 | 기본 실행 시각 |
+| --- | --- |
+| S3 전날 로그 업로드 | 매일 01:00 |
+| 일간/전체 랭킹 갱신 | 매일 03:00 |
+| 알림 정리 | 매일 03:30 |
+| 주간 랭킹 갱신 | 매주 월요일 04:00 |
+| 삭제 유저 물리 삭제 | 매일 04:30 |
+| 월간 랭킹 갱신 | 매월 1일 05:00 |
 
 팀 프로젝트 비용 최소화가 목적이면 로그 버킷은 장기 보관하지 않고 만료 정책을 설정합니다.
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
@@ -147,20 +147,23 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
     return queryFactory
       .select(Projections.constructor(
         BookRankQueryDto.class,
-        review.book.id,
+        book.id,
         review.id.countDistinct(),
         review.rating.avg().coalesce(0.0)
       ))
-      .from(review)
-      .where(
+      .from(book)
+      .leftJoin(review).on(
+        review.book.eq(book),
         review.isDeleted.isFalse(),
-        review.book.isDeleted.isFalse(),
-        review.createdAt.between(
-          startDate.atStartOfDay(),
-          endDate.atTime(LocalTime.MAX)
-        )
+        review.createdAt.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX))
       )
-      .groupBy(review.book.id)
+      .where(book.isDeleted.isFalse())
+      .groupBy(book.id)
+      .having(review.id.countDistinct().gt(0))
+      .orderBy(
+        review.id.countDistinct().desc(),
+        review.rating.avg().desc()
+      )
       .fetch();
   }
 
@@ -188,8 +191,8 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
         buildPopularBookCursorCondition(direction, cursor, after)
       )
       .orderBy(
-        buildPopularBookRankOrderSpecifier(direction),
-        buildPopularBookIdOrderSpecifier(direction)
+        popularBook.rankOrder.asc(),
+        popularBook.id.asc()
       )
       .limit(limit + 1L)
       .fetch();

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepositoryImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class PopularReviewRepositoryImpl implements PopularReviewRepositoryCustom {
+
   private final JPAQueryFactory queryFactory;
 
   @Override
@@ -27,9 +28,7 @@ public class PopularReviewRepositoryImpl implements PopularReviewRepositoryCusto
         popularReview.calculatedDate.eq(latestDate),
         cursorCondition(popularReview, cursor, direction)
       )
-      .orderBy(direction.equalsIgnoreCase("ASC") ?
-          popularReview.rankOrder.asc() : popularReview.rankOrder.desc()
-      )
+      .orderBy(popularReview.rankOrder.asc())
       .limit(limit + 1)
       .fetch();
   }
@@ -37,11 +36,6 @@ public class PopularReviewRepositoryImpl implements PopularReviewRepositoryCusto
   private BooleanExpression cursorCondition(QPopularReview pr, Integer cursor, String direction) {
     if (cursor == null)
       return null;
-
-    if (direction.equalsIgnoreCase("ASC")) {
-      return pr.rankOrder.gt(cursor);
-    } else {
-      return pr.rankOrder.lt(cursor);
-    }
+    return pr.rankOrder.gt(cursor);
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImpl.java
@@ -85,10 +85,12 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             comment.id.countDistinct()
         ))
         .from(review)
-        .leftJoin(reviewLike).on(reviewLike.review.eq(review))
-        .leftJoin(comment).on(comment.review.eq(review))
-        .where(review.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX)))
+        .leftJoin(reviewLike).on(reviewLike.review.eq(review)
+          .and(reviewLike.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX))))
+        .leftJoin(comment).on(comment.review.eq(review)
+          .and(comment.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX))))
         .groupBy(review.id)
+        .having(reviewLike.id.countDistinct().gt(0).or(comment.id.countDistinct().gt(0)))
         .fetch();
   }
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/batch/UserHardDeleteBatch.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/batch/UserHardDeleteBatch.java
@@ -5,16 +5,18 @@ import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserHardDeleteBatch {
   private final UserRepository userRepository;
 
-  @Scheduled(cron = "0 0 3 * * *")
+  @Scheduled(cron = "${deokhugam.batch.user-hard-delete.cron:0 30 4 * * *}", zone = "Asia/Seoul")
   @Transactional
   public void cleanupOldDeletedUsers() {
     LocalDateTime threshold = LocalDateTime.now().minusDays(1);
@@ -24,7 +26,6 @@ public class UserHardDeleteBatch {
     if (!targets.isEmpty()) {
       userRepository.deleteAllInBatch(targets);
     }
+    log.info("[Batch] User hard delete completed. deletedCount={}", targets.size());
   }
-
-
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadScheduler.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/DailyLogUploadScheduler.java
@@ -5,11 +5,13 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class DailyLogUploadScheduler {
 
@@ -31,9 +33,10 @@ public class DailyLogUploadScheduler {
     this.clock = clock;
   }
 
-  @Scheduled(cron = "${deokhugam.log.s3.upload-cron:0 10 0 * * *}", zone = "Asia/Seoul")
+  @Scheduled(cron = "${deokhugam.log.s3.upload-cron:0 0 1 * * *}", zone = "Asia/Seoul")
   public void uploadYesterdayLog() {
     LocalDate targetDate = LocalDate.now(clock).minusDays(1);
+    log.info("Daily log S3 upload started. targetDate={}", targetDate);
     Path targetFile = Path.of(localPath, "deokhugam.%s.log".formatted(targetDate));
 
     dailyLogS3Uploader.upload(targetDate, targetFile);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/NotificationCleanupScheduler.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/NotificationCleanupScheduler.java
@@ -19,9 +19,10 @@ public class NotificationCleanupScheduler {
   @Qualifier("notificationCleanupJob")
   private final Job notificationCleanupJob;
 
-  @Scheduled(cron = "0 0 3 * * *")
+  @Scheduled(cron = "${deokhugam.batch.notification-cleanup.cron:0 30 3 * * *}", zone = "Asia/Seoul")
   public void runNotificationCleanup() {
     try {
+      log.info("[Batch] Starting notification cleanup job...");
       jobLauncher.run(notificationCleanupJob, new JobParametersBuilder()
           .addLong("requestedAt", System.currentTimeMillis())
           .toJobParameters());

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/RankingScheduler.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/scheduler/RankingScheduler.java
@@ -21,7 +21,7 @@ public class RankingScheduler {
   private final Job rankingJob;
 
   // 1. 매일 새벽 3시: DAILY와 ALL_TIME을 함께 갱신 (홈 화면 데이터 보장)
-  @Scheduled(cron = "0 0 3 * * *")
+  @Scheduled(cron = "${deokhugam.batch.ranking.daily-cron:0 0 3 * * *}", zone = "Asia/Seoul")
   public void runDailyAndAllTimeRanking() {
     log.info("[Batch] Starting Daily and All-Time ranking jobs...");
     runJob(Period.DAILY);
@@ -29,14 +29,14 @@ public class RankingScheduler {
   }
 
   // 2. 매주 월요일 새벽 4시: WEEKLY 갱신
-  @Scheduled(cron = "0 0 4 * * MON")
+  @Scheduled(cron = "${deokhugam.batch.ranking.weekly-cron:0 0 4 * * MON}", zone = "Asia/Seoul")
   public void runWeeklyRanking() {
     log.info("[Batch] Starting Weekly ranking job...");
     runJob(Period.WEEKLY);
   }
 
   // 3. 매달 1일 새벽 5시: MONTHLY 갱신
-  @Scheduled(cron = "0 0 5 1 * *")
+  @Scheduled(cron = "${deokhugam.batch.ranking.monthly-cron:0 0 5 1 * *}", zone = "Asia/Seoul")
   public void runMonthlyRanking() {
     log.info("[Batch] Starting Monthly ranking job...");
     runJob(Period.MONTHLY);

--- a/deokhugam/src/main/resources/application.yml
+++ b/deokhugam/src/main/resources/application.yml
@@ -27,12 +27,21 @@ logging:
     file: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%X{clientIp}] %-5level %logger{36} - %msg%n"
 
 deokhugam:
+  batch:
+    ranking:
+      daily-cron: ${RANKING_DAILY_CRON:0 0 3 * * *}
+      weekly-cron: ${RANKING_WEEKLY_CRON:0 0 4 * * MON}
+      monthly-cron: ${RANKING_MONTHLY_CRON:0 0 5 1 * *}
+    notification-cleanup:
+      cron: ${NOTIFICATION_CLEANUP_CRON:0 30 3 * * *}
+    user-hard-delete:
+      cron: ${USER_HARD_DELETE_CRON:0 30 4 * * *}
   log:
     s3:
       bucket: ${S3_LOG_BUCKET:}
       prefix: ${S3_LOG_PREFIX:app}
       local-path: ${LOG_FILE_PATH:./logs}
-      upload-cron: ${S3_LOG_UPLOAD_CRON:0 10 0 * * *}
+      upload-cron: ${S3_LOG_UPLOAD_CRON:0 0 1 * * *}
       delete-after-upload: ${S3_LOG_DELETE_AFTER_UPLOAD:false}
 
 management:

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
@@ -1,0 +1,94 @@
+package com.deokhugam.deokhugam_server.domain.book.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BookEntityTest {
+
+  @Test
+  @DisplayName("도서를 생성하면 기본 리뷰 수와 평점은 0으로 초기화된다")
+  void constructor_success() {
+    Book book = new Book(
+      "클린 코드",
+      "로버트 마틴",
+      "9788966260959",
+      "인사이트",
+      "좋은 코드 작성법",
+      "thumbnail.jpg",
+      LocalDate.of(2013, 12, 24)
+    );
+
+    assertThat(book.getTitle()).isEqualTo("클린 코드");
+    assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
+    assertThat(book.getIsbn()).isEqualTo("9788966260959");
+    assertThat(book.getPublisher()).isEqualTo("인사이트");
+    assertThat(book.getDescription()).isEqualTo("좋은 코드 작성법");
+    assertThat(book.getThumbnailUrl()).isEqualTo("thumbnail.jpg");
+    assertThat(book.getPublishedDate()).isEqualTo(LocalDate.of(2013, 12, 24));
+    assertThat(book.getReviewCount()).isZero();
+    assertThat(book.getRating()).isZero();
+  }
+
+  @Test
+  @DisplayName("도서 정보를 수정한다")
+  void update_success() {
+    Book book = createBook();
+
+    book.update(
+      "수정된 제목",
+      "수정된 저자",
+      "수정된 출판사",
+      "수정된 설명",
+      "updated-thumbnail.jpg",
+      LocalDate.of(2025, 1, 1)
+    );
+
+    assertThat(book.getTitle()).isEqualTo("수정된 제목");
+    assertThat(book.getAuthor()).isEqualTo("수정된 저자");
+    assertThat(book.getPublisher()).isEqualTo("수정된 출판사");
+    assertThat(book.getDescription()).isEqualTo("수정된 설명");
+    assertThat(book.getThumbnailUrl()).isEqualTo("updated-thumbnail.jpg");
+    assertThat(book.getPublishedDate()).isEqualTo(LocalDate.of(2025, 1, 1));
+  }
+
+  @Test
+  @DisplayName("도서 수정 시 null 값은 기존 값을 유지한다")
+  void update_nullValues_keepOriginalValues() {
+    Book book = createBook();
+
+    book.update(null, null, null, null, null, null);
+
+    assertThat(book.getTitle()).isEqualTo("클린 코드");
+    assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
+    assertThat(book.getPublisher()).isEqualTo("인사이트");
+    assertThat(book.getDescription()).isEqualTo("좋은 코드 작성법");
+    assertThat(book.getThumbnailUrl()).isEqualTo("thumbnail.jpg");
+    assertThat(book.getPublishedDate()).isEqualTo(LocalDate.of(2013, 12, 24));
+  }
+
+  @Test
+  @DisplayName("리뷰 통계를 수정한다")
+  void updateReviewStatistics_success() {
+    Book book = createBook();
+
+    book.updateReviewStatistics(10, 4.5);
+
+    assertThat(book.getReviewCount()).isEqualTo(10);
+    assertThat(book.getRating()).isEqualTo(4.5);
+  }
+
+  private Book createBook() {
+    return new Book(
+      "클린 코드",
+      "로버트 마틴",
+      "9788966260959",
+      "인사이트",
+      "좋은 코드 작성법",
+      "thumbnail.jpg",
+      LocalDate.of(2013, 12, 24)
+    );
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
@@ -30,8 +30,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 @Import(QueryDslConfig.class)
 class BookRepositoryCustomImplTest {
 
-  @Autowired private BookRepository bookRepository;
-  @Autowired private EntityManager em;
+  @Autowired
+  private BookRepository bookRepository;
+
+  @Autowired
+  private EntityManager em;
 
   private Book cleanCode;
   private Book effectiveJava;
@@ -141,11 +144,70 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: ISBN 검색 시 하이픈을 제거하고 검색한다")
+  void searchBooks_KeywordIsbnHyphen_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      "978-2222222222",
+      "title",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).title()).isEqualTo("Effective Java");
+    assertThat(result.get(0).isbn()).isEqualTo("9782222222222");
+  }
+
+  @Test
   @DisplayName("성공: 제목 기준 오름차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByTitleAsc_Success() {
     BookSearchRequest request = new BookSearchRequest(
       null,
       "title",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("Clean Code");
+    assertThat(result.get(1).title()).isEqualTo("Effective Java");
+    assertThat(result.get(2).title()).isEqualTo("No Review Book");
+  }
+
+  @Test
+  @DisplayName("성공: 제목 기준 내림차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByTitleDesc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "title",
+      "DESC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("No Review Book");
+    assertThat(result.get(1).title()).isEqualTo("Effective Java");
+    assertThat(result.get(2).title()).isEqualTo("Clean Code");
+  }
+
+  @Test
+  @DisplayName("성공: 출간일 기준 오름차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByPublishedDateAsc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "publishedDate",
       "ASC",
       null,
       null,
@@ -181,6 +243,31 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 평점 기준 오름차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByRatingAsc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "rating",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("No Review Book");
+    assertThat(result.get(0).rating()).isEqualTo(0.0);
+
+    assertThat(result.get(1).title()).isEqualTo("Clean Code");
+    assertThat(result.get(1).rating()).isEqualTo(4.0);
+
+    assertThat(result.get(2).title()).isEqualTo("Effective Java");
+    assertThat(result.get(2).rating()).isEqualTo(5.0);
+  }
+
+  @Test
   @DisplayName("성공: 평점 기준 내림차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByRatingDesc_Success() {
     BookSearchRequest request = new BookSearchRequest(
@@ -206,6 +293,28 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 리뷰 수 기준 오름차순으로 도서 목록을 조회한다")
+  void searchBooks_OrderByReviewCountAsc_Success() {
+    BookSearchRequest request = new BookSearchRequest(
+      null,
+      "reviewCount",
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> result = bookRepository.searchBooks(request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).title()).isEqualTo("No Review Book");
+    assertThat(result.get(0).reviewCount()).isEqualTo(0);
+
+    assertThat(result.get(1).reviewCount()).isEqualTo(2);
+    assertThat(result.get(2).reviewCount()).isEqualTo(2);
+  }
+
+  @Test
   @DisplayName("성공: 리뷰 수 기준 내림차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByReviewCountDesc_Success() {
     BookSearchRequest request = new BookSearchRequest(
@@ -226,8 +335,8 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 커서 이후의 도서 목록을 조회한다")
-  void searchBooks_CursorPaging_Success() {
+  @DisplayName("성공: 제목 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_TitleCursorPaging_Success() {
     BookSearchRequest firstRequest = new BookSearchRequest(
       null,
       "title",
@@ -256,6 +365,102 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 출간일 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_PublishedDateCursorPaging_Success() {
+    BookSearchRequest firstRequest = new BookSearchRequest(
+      null,
+      "publishedDate",
+      "ASC",
+      null,
+      null,
+      2
+    );
+
+    List<BookSearchQueryDto> firstResult = bookRepository.searchBooks(firstRequest);
+    BookSearchQueryDto lastItem = firstResult.get(1);
+
+    BookSearchRequest nextRequest = new BookSearchRequest(
+      null,
+      "publishedDate",
+      "ASC",
+      lastItem.publishedDate().toString(),
+      lastItem.createdAt(),
+      10
+    );
+
+    List<BookSearchQueryDto> nextResult = bookRepository.searchBooks(nextRequest);
+
+    assertThat(nextResult).hasSize(1);
+    assertThat(nextResult.get(0).title()).isEqualTo("No Review Book");
+  }
+
+  @Test
+  @DisplayName("성공: 평점 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_RatingCursorPaging_Success() {
+    BookSearchRequest firstRequest = new BookSearchRequest(
+      null,
+      "rating",
+      "ASC",
+      null,
+      null,
+      2
+    );
+
+    List<BookSearchQueryDto> firstResult = bookRepository.searchBooks(firstRequest);
+    BookSearchQueryDto lastItem = firstResult.get(1);
+
+    BookSearchRequest nextRequest = new BookSearchRequest(
+      null,
+      "rating",
+      "ASC",
+      String.valueOf(lastItem.rating()),
+      lastItem.createdAt(),
+      10
+    );
+
+    List<BookSearchQueryDto> nextResult = bookRepository.searchBooks(nextRequest);
+
+    assertThat(nextResult).hasSize(1);
+    assertThat(nextResult.get(0).title()).isEqualTo("Effective Java");
+  }
+
+  @Test
+  @DisplayName("성공: 리뷰 수 기준 커서 이후의 도서 목록을 조회한다")
+  void searchBooks_ReviewCountCursorPaging_Success() {
+    BookSearchRequest firstRequest = new BookSearchRequest(
+      null,
+      "reviewCount",
+      "ASC",
+      null,
+      null,
+      2
+    );
+
+    List<BookSearchQueryDto> firstResult = bookRepository.searchBooks(firstRequest);
+
+    assertThat(firstResult).hasSize(3);
+
+    BookSearchQueryDto lastItem = firstResult.get(1);
+
+    BookSearchRequest nextRequest = new BookSearchRequest(
+      null,
+      "reviewCount",
+      "ASC",
+      String.valueOf(lastItem.reviewCount()),
+      lastItem.createdAt(),
+      10
+    );
+
+    List<BookSearchQueryDto> nextResult = bookRepository.searchBooks(nextRequest);
+
+    assertThat(nextResult).isNotNull();
+    assertThat(nextResult)
+      .allSatisfy(book ->
+        assertThat(book.reviewCount()).isGreaterThanOrEqualTo(lastItem.reviewCount())
+      );
+  }
+
+  @Test
   @DisplayName("성공: 삭제되지 않은 도서 수만 조회한다")
   void countBooks_Success() {
     long count = bookRepository.countBooks(new BookSearchRequest(
@@ -271,6 +476,21 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 키워드 검색 결과의 도서 수를 조회한다")
+  void countBooks_WithKeyword_Success() {
+    long count = bookRepository.countBooks(new BookSearchRequest(
+      "Java",
+      "title",
+      "ASC",
+      null,
+      null,
+      10
+    ));
+
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
   @DisplayName("성공: 도서 상세 조회 시 리뷰 수와 평균 평점을 함께 조회한다")
   void findBookDetail_Success() {
     BookSearchQueryDto result = bookRepository.findBookDetail(cleanCode.getId());
@@ -279,6 +499,14 @@ class BookRepositoryCustomImplTest {
     assertThat(result.title()).isEqualTo("Clean Code");
     assertThat(result.reviewCount()).isEqualTo(2);
     assertThat(result.rating()).isEqualTo(4.0);
+  }
+
+  @Test
+  @DisplayName("성공: 존재하지 않는 도서 상세 조회 시 null을 반환한다")
+  void findBookDetail_NotFound_ReturnsNull() {
+    BookSearchQueryDto result = bookRepository.findBookDetail(UUID.randomUUID());
+
+    assertThat(result).isNull();
   }
 
   @Test
@@ -309,8 +537,19 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 인기 도서 목록을 순위 기준으로 조회한다")
-  void findPopularBooksWithPaging_Success() {
+  @DisplayName("성공: 기간 밖의 리뷰는 통계 집계에서 제외된다")
+  void findBookStatisticsForRanking_OutOfRange_Excluded() {
+    List<BookRankQueryDto> result = bookRepository.findBookStatisticsForRanking(
+      BASE_TIME.plusDays(1).toLocalDate(),
+      BASE_TIME.plusDays(2).toLocalDate()
+    );
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 목록을 순위 기준 오름차순으로 조회한다")
+  void findPopularBooksWithPaging_Asc_Success() {
     List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
       Period.DAILY,
       "ASC",
@@ -326,8 +565,34 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
-  @DisplayName("성공: 인기 도서 커서 페이징이 정상 작동한다")
-  void findPopularBooksWithPaging_Cursor_Success() {
+  @DisplayName("성공: 인기 도서 목록을 DESC 방향으로 조회한다")
+  void findPopularBooksWithPaging_Desc_Success() {
+    List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
+      Period.DAILY,
+      "DESC",
+      null,
+      null,
+      10
+    );
+
+    assertThat(result).hasSize(3);
+
+    assertThat(result)
+      .extracting(PopularBook::getPeriodType)
+      .containsOnly(Period.DAILY);
+
+    assertThat(result)
+      .extracting(PopularBook::getCalculatedDate)
+      .containsOnly(RANK_DATE);
+
+    assertThat(result)
+      .extracting(PopularBook::getRankOrder)
+      .containsExactlyInAnyOrder(1, 2, 3);
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 커서 페이징이 오름차순으로 정상 작동한다")
+  void findPopularBooksWithPaging_AscCursor_Success() {
     List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
       Period.DAILY,
       "ASC",
@@ -339,6 +604,65 @@ class BookRepositoryCustomImplTest {
     assertThat(result).hasSize(2);
     assertThat(result.get(0).getRankOrder()).isEqualTo(2);
     assertThat(result.get(1).getRankOrder()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 조회 시 최신 집계일 데이터만 조회한다")
+  void findPopularBooksWithPaging_LatestCalculatedDateOnly_Success() {
+    persistPopularBook(
+      cleanCode,
+      Period.DAILY,
+      100.0,
+      99,
+      10L,
+      5.0,
+      RANK_DATE.minusDays(1)
+    );
+
+    em.flush();
+    em.clear();
+
+    List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
+      Period.DAILY,
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    assertThat(result).hasSize(3);
+    assertThat(result)
+      .extracting(PopularBook::getCalculatedDate)
+      .containsOnly(RANK_DATE);
+  }
+
+  @Test
+  @DisplayName("성공: 인기 도서 조회 시 기간 타입이 일치하는 데이터만 조회한다")
+  void findPopularBooksWithPaging_FilterByPeriod_Success() {
+    persistPopularBook(
+      cleanCode,
+      Period.WEEKLY,
+      100.0,
+      1,
+      10L,
+      5.0,
+      RANK_DATE
+    );
+
+    em.flush();
+    em.clear();
+
+    List<PopularBook> result = bookRepository.findPopularBooksWithPaging(
+      Period.WEEKLY,
+      "ASC",
+      null,
+      null,
+      10
+    );
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getPeriodType()).isEqualTo(Period.WEEKLY);
+    assertThat(result.get(0).getRankOrder()).isEqualTo(1);
   }
 
   private User persistUser(String prefix) {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/repository/PopularReviewRepositoryImplTest.java
@@ -1,0 +1,121 @@
+package com.deokhugam.deokhugam_server.domain.review.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
+import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
+import com.deokhugam.deokhugam_server.domain.review.entity.PopularReview;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.deokhugam.deokhugam_server.domain.user.repository.UserRepository;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(PopularReviewRepositoryImplTest.TestQueryDslConfig.class)
+@ActiveProfiles("test")
+class PopularReviewRepositoryImplTest {
+
+  @TestConfiguration
+  @EnableJpaAuditing
+  static class TestQueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+      return new JPAQueryFactory(entityManager);
+    }
+  }
+
+  @Autowired
+  private PopularReviewRepository popularReviewRepository;
+
+  @Autowired
+  private ReviewRepository reviewRepository;
+
+  @Autowired
+  private EntityManager entityManager;
+
+  @Autowired
+  private BookRepository bookRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private User testUser;
+  private final LocalDate targetDate = LocalDate.of(2026, 4, 30);
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+      .email("test@test.com")
+      .nickname("테스터")
+      .password("1234")
+      .build();
+    userRepository.save(testUser);
+  }
+
+  @Test
+  @DisplayName("인기 리뷰 조회: ASC 정렬 및 커서 기반 페이징이 정확히 작동한다")
+  void findPopularReviewDynamic_Pagination_Success() {
+    for (int i = 1; i <= 5; i++) {
+      createPopularReviewSet(i);
+    }
+
+    entityManager.flush();
+    entityManager.clear();
+
+    int cursor = 2;
+    int limit = 2;
+    List<PopularReview> result = popularReviewRepository.findPopularReviewDynamic(
+      Period.WEEKLY, cursor, null, "ASC", limit, targetDate
+    );
+
+    assertThat(result).hasSize(limit + 1)
+      .extracting(PopularReview::getRankOrder)
+      .containsExactly(3, 4, 5);
+
+    assertThat(result.get(0).getReview().getContent()).contains("리뷰 내용 3");
+  }
+
+
+  private void createPopularReviewSet(int index) {
+    Book book = new Book(
+      "테스트 책 " + index, "작가 " + index, "ISBN-000" + index,
+      "데브 출판사", "설명", "http://image.com", LocalDate.now()
+    );
+    bookRepository.save(book);
+
+    Review review = Review.builder()
+      .content("리뷰 내용 " + index)
+      .user(testUser)
+      .book(book)
+      .rating(5)
+      .build();
+    reviewRepository.save(review);
+
+    PopularReview popularReview = PopularReview.builder()
+      .review(review)
+      .periodType(Period.WEEKLY)
+      .rankOrder(index)
+      .score(10.0)
+      .calculatedDate(targetDate)
+      .build();
+    popularReviewRepository.save(popularReview);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/PowerUserRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/PowerUserRepositoryImplTest.java
@@ -1,0 +1,106 @@
+package com.deokhugam.deokhugam_server.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.domain.user.entity.PowerUser;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(PowerUserRepositoryImplTest.TestQueryDslConfig.class)
+@ActiveProfiles("test")
+class PowerUserRepositoryImplTest {
+
+  @TestConfiguration
+  @EnableJpaAuditing
+  static class TestQueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+      return new JPAQueryFactory(entityManager);
+    }
+  }
+
+  @Autowired private PowerUserRepository powerUserRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private EntityManager em;
+
+  private final LocalDate targetDate = LocalDate.of(2026, 4, 30);
+
+  @Test
+  @DisplayName("파워 유저 조회: DESC 정렬 시 커서보다 큰 순위 숫자들이 내림차순으로 반환된다")
+  void findPowerUsersDynamic_Pagination_Success() {
+    // given
+    int totalCount = 5;
+    setupPowerUsers(totalCount);
+
+    em.flush();
+    em.clear();
+
+    // when
+    int cursor = 2;
+    int limit = 2;
+    List<PowerUser> result = powerUserRepository.findPowerUsersDynamic(
+      Period.WEEKLY, cursor, null, "DESC", limit, targetDate
+    );
+
+    // then
+    assertThat(result).hasSize(limit + 1)
+      .extracting(PowerUser::getRankOrder)
+      .containsExactly(5, 4, 3);
+
+    assertThat(result.get(0).getUser().getNickname()).isEqualTo("활동왕5");
+  }
+
+  @Test
+  @DisplayName("파워 유저 조회: 커서가 null이면 첫 번째 페이지부터 반환된다")
+  void findPowerUsersDynamic_FirstPage_Success() {
+    // given
+    setupPowerUsers(3);
+    em.flush();
+    em.clear();
+
+    // when
+    List<PowerUser> result = powerUserRepository.findPowerUsersDynamic(
+      Period.WEEKLY, null, null, "DESC", 2, targetDate
+    );
+
+    // then
+    assertThat(result).extracting(PowerUser::getRankOrder)
+      .contains(3, 2);
+  }
+
+  private void setupPowerUsers(int count) {
+    for (int i = 1; i <= count; i++) {
+      User user = userRepository.save(User.builder()
+        .email("user" + i + "@test.com")
+        .nickname("활동왕" + i)
+        .password("password123")
+        .build());
+
+      powerUserRepository.save(PowerUser.builder()
+        .user(user)
+        .periodType(Period.WEEKLY)
+        .rankOrder(i)
+        .score(100.0)
+        .calculatedDate(targetDate)
+        .build());
+    }
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryCustomImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepositoryCustomImplTest.java
@@ -1,0 +1,124 @@
+package com.deokhugam.deokhugam_server.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
+import com.deokhugam.deokhugam_server.domain.book.repository.BookRepository;
+import com.deokhugam.deokhugam_server.domain.comment.entity.Comment;
+import com.deokhugam.deokhugam_server.domain.comment.repository.CommentRepository;
+import com.deokhugam.deokhugam_server.domain.review.entity.Review;
+import com.deokhugam.deokhugam_server.domain.review.entity.ReviewLike;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewLikeRepository;
+import com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepository;
+import com.deokhugam.deokhugam_server.domain.user.dto.response.UserRankQueryDto;
+import com.deokhugam.deokhugam_server.domain.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(UserRepositoryCustomImplTest.TestQueryDslConfig.class)
+@ActiveProfiles("test")
+class UserRepositoryCustomImplTest {
+
+  @TestConfiguration
+  @EnableJpaAuditing
+  static class TestQueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+      return new JPAQueryFactory(entityManager);
+    }
+  }
+
+  @Autowired private UserRepository userRepository;
+  @Autowired private ReviewRepository reviewRepository;
+  @Autowired private ReviewLikeRepository reviewLikeRepository;
+  @Autowired private CommentRepository commentRepository;
+  @Autowired private BookRepository bookRepository;
+  @Autowired private EntityManager em;
+
+  @Test
+  @DisplayName("지정된 기간 내의 사용자 활동(리뷰, 좋아요, 댓글) 통계를 정확히 조회한다")
+  void findUserActivityStatistics_Success() {
+    // given
+    LocalDate start = LocalDate.now().minusDays(1);
+    LocalDate end = LocalDate.now();
+    User activeUser = createUser("active@test.com", "활동유저");
+
+    setupUserActivities(activeUser);
+
+    em.flush();
+    em.clear();
+
+    // when
+    List<UserRankQueryDto> result = userRepository.findUserActivityStatistics(start, end);
+
+    // then
+    assertThat(result).hasSize(1);
+
+    assertThat(result.get(0))
+      .extracting(
+        UserRankQueryDto::userId,
+        UserRankQueryDto::totalReviewScore,
+        UserRankQueryDto::givenLikeCount,
+        UserRankQueryDto::writtenCommentCount
+      )
+      .containsExactly(activeUser.getId(), 2L, 1L, 1L);
+  }
+
+  private void setupUserActivities(User user) {
+    Book book1 = createBook("ISBN-111", "테스트 책 1");
+    Review review1 = saveReview(user, book1, "리뷰1");
+
+    Book book2 = createBook("ISBN-222", "테스트 책 2");
+    saveReview(user, book2, "리뷰2");
+
+    reviewLikeRepository.save(ReviewLike.builder()
+      .user(user)
+      .review(review1)
+      .build());
+
+    commentRepository.save(Comment.builder()
+      .userId(user.getId())
+      .review(review1)
+      .content("댓글입니다")
+      .build());
+  }
+
+  private User createUser(String email, String nickname) {
+    return userRepository.save(User.builder()
+      .email(email)
+      .nickname(nickname)
+      .password("password")
+      .build());
+  }
+
+  private Book createBook(String isbn, String title) {
+    return bookRepository.save(new Book(
+      title, "저자", isbn, "출판사", "설명", "url", LocalDate.now()
+    ));
+  }
+
+  private Review saveReview(User user, Book book, String content) {
+    return reviewRepository.save(Review.builder()
+      .user(user)
+      .book(book)
+      .content(content)
+      .rating(5)
+      .build());
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/NotificationCleanupSchedulerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/NotificationCleanupSchedulerTest.java
@@ -1,0 +1,58 @@
+package com.deokhugam.deokhugam_server.global.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCleanupSchedulerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job notificationCleanupJob;
+
+  @Test
+  @DisplayName("성공: 알림 정리 배치를 실행한다")
+  void runNotificationCleanup_LaunchesJob() throws Exception {
+    NotificationCleanupScheduler scheduler = new NotificationCleanupScheduler(
+        jobLauncher,
+        notificationCleanupJob
+    );
+
+    scheduler.runNotificationCleanup();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getLong("requestedAt")).isNotNull();
+  }
+
+  @Test
+  @DisplayName("실패: 알림 정리 배치 실행 예외는 스케줄러 밖으로 전파하지 않는다")
+  void runNotificationCleanup_WhenJobLaunchFails_DoesNotThrow() throws Exception {
+    NotificationCleanupScheduler scheduler = new NotificationCleanupScheduler(
+        jobLauncher,
+        notificationCleanupJob
+    );
+    doThrow(new JobExecutionAlreadyRunningException("already running"))
+        .when(jobLauncher)
+        .run(any(Job.class), any(JobParameters.class));
+
+    scheduler.runNotificationCleanup();
+
+    verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/RankingSchedulerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/scheduler/RankingSchedulerTest.java
@@ -1,0 +1,83 @@
+package com.deokhugam.deokhugam_server.global.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+
+@ExtendWith(MockitoExtension.class)
+class RankingSchedulerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job rankingJob;
+
+  @Test
+  @DisplayName("성공: 일간과 전체 랭킹 배치를 함께 실행한다")
+  void runDailyAndAllTimeRanking_LaunchesDailyAndAllTimeJobs() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+
+    scheduler.runDailyAndAllTimeRanking();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher, times(2)).run(any(Job.class), captor.capture());
+    List<String> periods = captor.getAllValues().stream()
+        .map(params -> params.getString("period"))
+        .toList();
+    assertThat(periods).containsExactly(Period.DAILY.name(), Period.ALL_TIME.name());
+  }
+
+  @Test
+  @DisplayName("성공: 주간 랭킹 배치를 실행한다")
+  void runWeeklyRanking_LaunchesWeeklyJob() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+
+    scheduler.runWeeklyRanking();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getString("period")).isEqualTo(Period.WEEKLY.name());
+  }
+
+  @Test
+  @DisplayName("성공: 월간 랭킹 배치를 실행한다")
+  void runMonthlyRanking_LaunchesMonthlyJob() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+
+    scheduler.runMonthlyRanking();
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getString("period")).isEqualTo(Period.MONTHLY.name());
+  }
+
+  @Test
+  @DisplayName("실패: 랭킹 배치 실행 예외는 스케줄러 밖으로 전파하지 않는다")
+  void runWeeklyRanking_WhenJobLaunchFails_DoesNotThrow() throws Exception {
+    RankingScheduler scheduler = new RankingScheduler(jobLauncher, rankingJob);
+    doThrow(new JobExecutionAlreadyRunningException("already running"))
+        .when(jobLauncher)
+        .run(any(Job.class), any(JobParameters.class));
+
+    scheduler.runWeeklyRanking();
+
+    verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/type/PeriodTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/type/PeriodTest.java
@@ -1,0 +1,41 @@
+package com.deokhugam.deokhugam_server.global.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PeriodTest {
+
+  @Test
+  @DisplayName("성공: 대소문자와 무관하게 기간 값을 변환한다")
+  void from_ValidValue() {
+    assertThat(Period.from("daily")).isEqualTo(Period.DAILY);
+    assertThat(Period.from("WEEKLY")).isEqualTo(Period.WEEKLY);
+    assertThat(Period.from("monthly")).isEqualTo(Period.MONTHLY);
+    assertThat(Period.from("all_time")).isEqualTo(Period.ALL_TIME);
+  }
+
+  @Test
+  @DisplayName("실패: null 또는 blank 기간 값이면 예외를 던진다")
+  void from_NullOrBlank_ThrowsException() {
+    assertInvalidPeriod(null);
+    assertInvalidPeriod(" ");
+  }
+
+  @Test
+  @DisplayName("실패: 지원하지 않는 기간 값이면 예외를 던진다")
+  void from_InvalidValue_ThrowsException() {
+    assertInvalidPeriod("yearly");
+  }
+
+  private void assertInvalidPeriod(String value) {
+    assertThatThrownBy(() -> Period.from(value))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_PERIOD);
+  }
+}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/S3UtilTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/util/S3UtilTest.java
@@ -1,0 +1,168 @@
+package com.deokhugam.deokhugam_server.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3UtilTest {
+
+  private static final String BUCKET = "deokhugam-storage";
+  private static final String REGION = "ap-northeast-2";
+
+  @Mock
+  private S3Client s3Client;
+
+  @Mock
+  private S3Presigner s3Presigner;
+
+  private S3Util s3Util;
+
+  @BeforeEach
+  void setUp() {
+    s3Util = new S3Util(s3Client, s3Presigner);
+    ReflectionTestUtils.setField(s3Util, "bucket", BUCKET);
+    ReflectionTestUtils.setField(s3Util, "region", REGION);
+    ReflectionTestUtils.setField(s3Util, "presignedUrlExpirationSeconds", 3600L);
+  }
+
+  @Test
+  @DisplayName("성공: 파일을 S3에 업로드하고 관리 URL을 반환한다")
+  void upload_Success() {
+    MockMultipartFile file = new MockMultipartFile(
+        "file",
+        "cover.png",
+        "image/png",
+        "image".getBytes()
+    );
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    String result = s3Util.upload(file, "books");
+
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3Client).putObject(captor.capture(), any(RequestBody.class));
+    PutObjectRequest request = captor.getValue();
+    assertThat(request.bucket()).isEqualTo(BUCKET);
+    assertThat(request.key()).startsWith("books/").endsWith("_cover.png");
+    assertThat(request.contentType()).isEqualTo("image/png");
+    assertThat(request.contentLength()).isEqualTo(file.getSize());
+    assertThat(result).startsWith("https://deokhugam-storage.s3.ap-northeast-2.amazonaws.com/books/");
+    assertThat(result).endsWith("_cover.png");
+  }
+
+  @Test
+  @DisplayName("실패: 파일 업로드 중 예외가 발생하면 S3 업로드 예외를 던진다")
+  void upload_WhenFails_ThrowsException() throws Exception {
+    MockMultipartFile file = new FailingMultipartFile();
+
+    assertThatThrownBy(() -> s3Util.upload(file, "books"))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.S3_UPLOAD_FAILED);
+  }
+
+  @Test
+  @DisplayName("성공: null 또는 blank URL 삭제는 건너뛴다")
+  void delete_NullOrBlank_SkipsDelete() {
+    s3Util.delete(null);
+    s3Util.delete(" ");
+
+    verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+  }
+
+  @Test
+  @DisplayName("성공: S3 URL에서 key를 추출해 객체를 삭제한다")
+  void delete_Success() {
+    String fileUrl = managedUrl("books/cover.png");
+    when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3Util.delete(fileUrl);
+
+    ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+    verify(s3Client).deleteObject(captor.capture());
+    assertThat(captor.getValue().bucket()).isEqualTo(BUCKET);
+    assertThat(captor.getValue().key()).isEqualTo("books/cover.png");
+  }
+
+  @Test
+  @DisplayName("실패: S3 형식이 아닌 URL 삭제 시 삭제 예외를 던진다")
+  void delete_InvalidUrl_ThrowsException() {
+    assertThatThrownBy(() -> s3Util.delete("https://example.com/image.png"))
+        .isInstanceOf(DeokhugamException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.S3_DELETE_FAILED);
+  }
+
+  @Test
+  @DisplayName("성공: 관리 대상 S3 URL이면 presigned URL로 변환한다")
+  void toPresignedUrlIfS3Url_ManagedUrl_ReturnsPresignedUrl() throws Exception {
+    String fileUrl = managedUrl("books/cover.png");
+    PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
+    when(presignedRequest.url())
+        .thenReturn(new URL("https://presigned.example.com/books/cover.png"));
+    when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class)))
+        .thenReturn(presignedRequest);
+
+    String result = s3Util.toPresignedUrlIfS3Url(fileUrl);
+
+    assertThat(result).isEqualTo("https://presigned.example.com/books/cover.png");
+    verify(s3Presigner).presignGetObject(any(GetObjectPresignRequest.class));
+  }
+
+  @Test
+  @DisplayName("성공: 관리 대상이 아닌 URL은 그대로 반환한다")
+  void toPresignedUrlIfS3Url_NotManaged_ReturnsOriginal() {
+    assertThat(s3Util.toPresignedUrlIfS3Url(null)).isNull();
+    assertThat(s3Util.toPresignedUrlIfS3Url(" ")).isEqualTo(" ");
+    assertThat(s3Util.toPresignedUrlIfS3Url("https://example.com/image.png"))
+        .isEqualTo("https://example.com/image.png");
+
+    verify(s3Presigner, never()).presignGetObject(any(GetObjectPresignRequest.class));
+  }
+
+  private String managedUrl(String key) {
+    return "https://%s.s3.%s.amazonaws.com/%s".formatted(BUCKET, REGION, key);
+  }
+
+  private static class FailingMultipartFile extends MockMultipartFile {
+
+    FailingMultipartFile() {
+      super("file", "cover.png", "image/png", new byte[0]);
+    }
+
+    @Override
+    public java.io.InputStream getInputStream() throws IOException {
+      throw new IOException("read failed");
+    }
+  }
+}

--- a/task-definition.json
+++ b/task-definition.json
@@ -52,6 +52,30 @@
           "value": "false"
         },
         {
+          "name": "S3_LOG_UPLOAD_CRON",
+          "value": "0 0 1 * * *"
+        },
+        {
+          "name": "RANKING_DAILY_CRON",
+          "value": "0 0 3 * * *"
+        },
+        {
+          "name": "RANKING_WEEKLY_CRON",
+          "value": "0 0 4 * * MON"
+        },
+        {
+          "name": "RANKING_MONTHLY_CRON",
+          "value": "0 0 5 1 * *"
+        },
+        {
+          "name": "NOTIFICATION_CLEANUP_CRON",
+          "value": "0 30 3 * * *"
+        },
+        {
+          "name": "USER_HARD_DELETE_CRON",
+          "value": "0 30 4 * * *"
+        },
+        {
           "name": "SPRING_PROFILES_ACTIVE",
           "value": "dev"
         }


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/dev-v1-1-3526e443c28880a78a37d28c628ff4f5?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- 운영 배포 이후 확인된 도서/리뷰 이미지 표시 문제를 수정했습니다.
- 인기 리뷰, 인기 도서, 파워 유저 랭킹 조회 결과가 정상적으로 표시되지 않던 문제를 수정했습니다.
- S3 날짜별 로그 적재 시 로그 파일 롤링 타이밍 문제로 업로드가 건너뛰어질 수 있는 문제를 수정했습니다.
- 운영 배치 스케줄이 서버 기본 시간대에 의존하던 문제를 수정했습니다.

### ✨ 기능 추가 / 구현
- S3 날짜별 로그 적재 기능을 운영 환경 기준으로 보완했습니다.
- 랭킹, 알림 정리, 유저 물리 삭제 배치가 `Asia/Seoul` 기준으로 실행되도록 설정했습니다.
- Global, Dashboard, Book Repository 등 테스트 코드를 보강해 전체 커버리지 80% 이상을 달성했습니다.
- 운영 환경에서 로그 및 배치 스케줄을 ECS 환경변수로 관리할 수 있도록 반영했습니다.

### ♻️ 리팩토링
- 도서 정렬 및 커서 페이지네이션 로직을 보완했습니다.
- Dashboard/Ranking 관련 Repository 조회 로직을 안정화했습니다.
- 운영 배치 실행 시간이 한 시점에 몰리지 않도록 새벽 시간대로 분산했습니다.
- AWS 배포 문서와 운영 확인 절차를 최신화했습니다.

### ⚙️ 설정 변경
- ECS Task Definition의 환경변수 및 배포 설정을 최신화했습니다.
- S3 로그 업로드 스케줄을 매일 `01:00 Asia/Seoul` 기준으로 조정했습니다.
- 주요 배치 스케줄을 KST 기준 새벽 시간대로 조정했습니다.
- README 커버리지 배지 및 AWS 운영 문서를 갱신했습니다.

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] 전체 테스트 및 커버리지 검증 통과 확인 (`./gradlew clean test jacocoTestReport jacocoTestCoverageVerification`)
- [x] CD 배포 완료 후 운영 환경 smoke test 확인
- [x] S3 로그 적재 실행 결과 확인

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-RELEASE] 운영 배포 반영 v1.1`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 첫 번째 main 배포 이후 확인된 운영 이슈와 테스트 커버리지 보강 작업을 main에 반영하는 두 번째 운영 배포 PR입니다.
- PR merge 시 GitHub Actions CD가 실행되어 ECR 이미지 빌드/푸시 및 ECS 서비스 업데이트가 진행됩니다.
- S3 로그 적재는 배포 후 다음 실행 시점 이후 `s3://deokhugam-logs-297904/app/yyyy/MM/dd/` 경로에서 확인해야 합니다.
- 배치 실행 여부는 CloudWatch Logs와 Spring Batch 메타 테이블에서 확인할 수 있습니다.
- 민감 정보는 포함하지 않았으며, 운영 환경 값은 AWS Secrets Manager 및 ECS 환경변수 기준으로 관리됩니다.

