### PR TITLE
[BE-120] Fix: 도서 제목 정렬용 키 추가

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
@@ -1,13 +1,17 @@
 package com.deokhugam.deokhugam_server.domain.book.entity;
 
 import com.deokhugam.deokhugam_server.global.entity.BaseEntity;
+import java.text.Normalizer;
+import java.time.LocalDate;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +23,8 @@ import org.hibernate.annotations.UuidGenerator;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Book extends BaseEntity {
 
+  private static final Pattern DIGIT_PATTERN = Pattern.compile("\\d+");
+
   @Id
   @GeneratedValue
   @UuidGenerator
@@ -27,6 +33,9 @@ public class Book extends BaseEntity {
 
   @Column(name = "title", nullable = false, length = 255)
   private String title;
+
+  @Column(name = "title_sort_key", nullable = false, length = 500)
+  private String titleSortKey;
 
   @Column(name = "author", nullable = false, length = 255)
   private String author;
@@ -62,6 +71,7 @@ public class Book extends BaseEntity {
     LocalDate publishedDate
   ) {
     this.title = title;
+    this.titleSortKey = toTitleSortKey(title);
     this.author = author;
     this.isbn = isbn;
     this.publisher = publisher;
@@ -82,6 +92,7 @@ public class Book extends BaseEntity {
   ) {
     if (title != null) {
       this.title = title;
+      this.titleSortKey = toTitleSortKey(title);
     }
     if (author != null) {
       this.author = author;
@@ -103,5 +114,35 @@ public class Book extends BaseEntity {
   public void updateReviewStatistics(int reviewCount, double rating) {
     this.reviewCount = reviewCount;
     this.rating = rating;
+  }
+
+  public static String toTitleSortKey(String title) {
+    if (title == null || title.isBlank()) {
+      return "";
+    }
+
+    String normalized = Normalizer.normalize(title.trim(), Normalizer.Form.NFKC)
+      .toLowerCase(Locale.ROOT)
+      .replaceAll("[\\p{Punct}\\p{IsPunctuation}]+", " ")
+      .replaceAll("\\s+", " ")
+      .trim();
+
+    Matcher matcher = DIGIT_PATTERN.matcher(normalized);
+    StringBuilder sortKey = new StringBuilder();
+
+    while (matcher.find()) {
+      matcher.appendReplacement(sortKey, padNumber(matcher.group()));
+    }
+    matcher.appendTail(sortKey);
+
+    return sortKey.toString();
+  }
+
+  private static String padNumber(String value) {
+    String normalizedNumber = value.replaceFirst("^0+(?!$)", "");
+    if (normalizedNumber.length() >= 20) {
+      return normalizedNumber;
+    }
+    return "0".repeat(20 - normalizedNumber.length()) + normalizedNumber;
   }
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import static com.deokhugam.deokhugam_server.domain.review.entity.QReview.review
 import com.deokhugam.deokhugam_server.domain.book.dto.request.BookSearchRequest;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookRankQueryDto;
 import com.deokhugam.deokhugam_server.domain.book.dto.response.BookSearchQueryDto;
+import com.deokhugam.deokhugam_server.domain.book.entity.Book;
 import com.deokhugam.deokhugam_server.domain.book.entity.PopularBook;
 import com.deokhugam.deokhugam_server.domain.book.entity.QPopularBook;
 import com.deokhugam.deokhugam_server.global.type.Period;
@@ -65,6 +66,7 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
       .groupBy(
         book.id,
         book.title,
+        book.titleSortKey,
         book.author,
         book.description,
         book.publisher,
@@ -262,13 +264,15 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
     LocalDateTime after,
     String direction
   ) {
+    String titleSortKeyCursor = Book.toTitleSortKey(cursor);
+
     if (isAsc(direction)) {
-      return book.title.gt(cursor)
-        .or(book.title.eq(cursor).and(book.createdAt.gt(after)));
+      return book.titleSortKey.gt(titleSortKeyCursor)
+        .or(book.titleSortKey.eq(titleSortKeyCursor).and(book.createdAt.gt(after)));
     }
 
-    return book.title.lt(cursor)
-      .or(book.title.eq(cursor).and(book.createdAt.lt(after)));
+    return book.titleSortKey.lt(titleSortKeyCursor)
+      .or(book.titleSortKey.eq(titleSortKeyCursor).and(book.createdAt.lt(after)));
   }
 
   private BooleanExpression comparePublishedDateCursor(
@@ -354,8 +358,8 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
       case "publisheddate" -> new OrderSpecifier<>(order, book.publishedDate);
       case "rating" -> new OrderSpecifier<>(order, ratingExpression);
       case "reviewcount" -> new OrderSpecifier<>(order, reviewCountExpression);
-      case "title" -> new OrderSpecifier<>(order, book.title);
-      default -> new OrderSpecifier<>(order, book.title);
+      case "title" -> new OrderSpecifier<>(order, book.titleSortKey);
+      default -> new OrderSpecifier<>(order, book.titleSortKey);
     };
   }
 

--- a/deokhugam/src/main/resources/db/migration/V4__add_book_title_sort_key.sql
+++ b/deokhugam/src/main/resources/db/migration/V4__add_book_title_sort_key.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION deokhugam_title_sort_key(input_title TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    source_text TEXT := regexp_replace(
+        regexp_replace(lower(btrim(coalesce(input_title, ''))), '[[:punct:]]+', ' ', 'g'),
+        '[[:space:]]+',
+        ' ',
+        'g'
+    );
+    result_text TEXT := '';
+    digit_buffer TEXT := '';
+    current_char TEXT;
+    index_value INTEGER;
+BEGIN
+    FOR index_value IN 1..char_length(source_text) LOOP
+        current_char := substr(source_text, index_value, 1);
+
+        IF current_char ~ '[0-9]' THEN
+            digit_buffer := digit_buffer || current_char;
+        ELSE
+            IF digit_buffer <> '' THEN
+                digit_buffer := regexp_replace(digit_buffer, '^0+(?!$)', '');
+                IF char_length(digit_buffer) < 20 THEN
+                    result_text := result_text || lpad(digit_buffer, 20, '0');
+                ELSE
+                    result_text := result_text || digit_buffer;
+                END IF;
+                digit_buffer := '';
+            END IF;
+
+            result_text := result_text || current_char;
+        END IF;
+    END LOOP;
+
+    IF digit_buffer <> '' THEN
+        digit_buffer := regexp_replace(digit_buffer, '^0+(?!$)', '');
+        IF char_length(digit_buffer) < 20 THEN
+            result_text := result_text || lpad(digit_buffer, 20, '0');
+        ELSE
+            result_text := result_text || digit_buffer;
+        END IF;
+    END IF;
+
+    RETURN btrim(result_text);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+ALTER TABLE books
+    ADD COLUMN IF NOT EXISTS title_sort_key VARCHAR(500);
+
+UPDATE books
+SET title_sort_key = deokhugam_title_sort_key(title)
+WHERE title_sort_key IS NULL OR title_sort_key = '';
+
+ALTER TABLE books
+    ALTER COLUMN title_sort_key SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_books_title_sort_key_created_at
+    ON books (title_sort_key, created_at DESC);
+
+DROP FUNCTION IF EXISTS deokhugam_title_sort_key(TEXT);

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
@@ -22,6 +22,7 @@ class BookEntityTest {
     );
 
     assertThat(book.getTitle()).isEqualTo("클린 코드");
+    assertThat(book.getTitleSortKey()).isEqualTo("클린 코드");
     assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
     assertThat(book.getIsbn()).isEqualTo("9788966260959");
     assertThat(book.getPublisher()).isEqualTo("인사이트");
@@ -47,6 +48,7 @@ class BookEntityTest {
     );
 
     assertThat(book.getTitle()).isEqualTo("수정된 제목");
+    assertThat(book.getTitleSortKey()).isEqualTo("수정된 제목");
     assertThat(book.getAuthor()).isEqualTo("수정된 저자");
     assertThat(book.getPublisher()).isEqualTo("수정된 출판사");
     assertThat(book.getDescription()).isEqualTo("수정된 설명");
@@ -62,6 +64,7 @@ class BookEntityTest {
     book.update(null, null, null, null, null, null);
 
     assertThat(book.getTitle()).isEqualTo("클린 코드");
+    assertThat(book.getTitleSortKey()).isEqualTo("클린 코드");
     assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
     assertThat(book.getPublisher()).isEqualTo("인사이트");
     assertThat(book.getDescription()).isEqualTo("좋은 코드 작성법");
@@ -78,6 +81,14 @@ class BookEntityTest {
 
     assertThat(book.getReviewCount()).isEqualTo(10);
     assertThat(book.getRating()).isEqualTo(4.5);
+  }
+
+  @Test
+  @DisplayName("정렬용 제목 키는 대소문자, 구두점, 숫자 자릿수를 정규화한다")
+  void toTitleSortKey_mixedTitle_success() {
+    assertThat(Book.toTitleSortKey(" Book-10 ")).isEqualTo("book 00000000000000000010");
+    assertThat(Book.toTitleSortKey("book 2")).isEqualTo("book 00000000000000000002");
+    assertThat(Book.toTitleSortKey("정렬-Banana")).isEqualTo("정렬 banana");
   }
 
   private Book createBook() {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
@@ -203,6 +203,76 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 한글, 영문, 숫자, 대소문자가 섞인 제목을 정렬용 키 기준으로 조회한다")
+  void searchBooks_OrderByTitleSortKeyMixedCharacters_Success() {
+    persistBook(
+      "정렬-Banana",
+      "테스터",
+      "9790000000001",
+      LocalDate.of(2024, 1, 1),
+      BASE_TIME.plusDays(1)
+    );
+    persistBook(
+      "정렬-apple",
+      "테스터",
+      "9790000000002",
+      LocalDate.of(2024, 1, 2),
+      BASE_TIME.plusDays(2)
+    );
+    persistBook(
+      "정렬-10",
+      "테스터",
+      "9790000000003",
+      LocalDate.of(2024, 1, 3),
+      BASE_TIME.plusDays(3)
+    );
+    persistBook(
+      "정렬-2",
+      "테스터",
+      "9790000000004",
+      LocalDate.of(2024, 1, 4),
+      BASE_TIME.plusDays(4)
+    );
+    persistBook(
+      "정렬-가나다",
+      "테스터",
+      "9790000000005",
+      LocalDate.of(2024, 1, 5),
+      BASE_TIME.plusDays(5)
+    );
+
+    em.flush();
+    em.clear();
+
+    BookSearchRequest ascRequest = new BookSearchRequest(
+      "정렬",
+      "title",
+      "ASC",
+      null,
+      null,
+      10
+    );
+    BookSearchRequest descRequest = new BookSearchRequest(
+      "정렬",
+      "title",
+      "DESC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> ascResult = bookRepository.searchBooks(ascRequest);
+    List<BookSearchQueryDto> descResult = bookRepository.searchBooks(descRequest);
+
+    assertThat(ascResult)
+      .extracting(BookSearchQueryDto::title)
+      .containsExactly("정렬-2", "정렬-10", "정렬-apple", "정렬-Banana", "정렬-가나다");
+    assertThat(descResult)
+      .extracting(BookSearchQueryDto::title)
+      .containsExactly("정렬-가나다", "정렬-Banana", "정렬-apple", "정렬-10", "정렬-2");
+  }
+
+  @Test
   @DisplayName("성공: 출간일 기준 오름차순으로 도서 목록을 조회한다")
   void searchBooks_OrderByPublishedDateAsc_Success() {
     BookSearchRequest request = new BookSearchRequest(


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/Book-3526e443c28880939ffcebfc34753cdc?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- 도서 제목 정렬 시 DB 기본 collation에 의존해 한글/영문/숫자/대소문자가 섞인 제목의 정렬 순서가 일관되지 않을 수 있는 문제를 개선했습니다.
- 제목 정렬 커서 비교 기준을 원본 `title`이 아닌 정렬용 키 기준으로 변경해 페이지 이동 시 정렬 순서가 흔들리지 않도록 수정했습니다.

### ✨ 기능 추가 / 구현
- `books.title_sort_key` 컬럼을 추가해 도서 제목 정렬 전용 값을 저장하도록 구현했습니다.
- 도서 생성 및 제목 수정 시 `titleSortKey`가 자동으로 갱신되도록 처리했습니다.
- 기존 도서 데이터에 대해 Flyway 마이그레이션으로 `title_sort_key`를 backfill하도록 추가했습니다.

### ♻️ 리팩토링
- 도서 목록 조회의 제목 정렬 기준을 `book.title`에서 `book.titleSortKey`로 변경했습니다.
- 정렬용 키 생성 로직을 `Book.toTitleSortKey()`로 분리해 엔티티 생성/수정/커서 비교에서 동일 기준을 사용하도록 정리했습니다.

### ⚙️ 설정 변경
- Flyway 마이그레이션 `V4__add_book_title_sort_key.sql`을 추가했습니다.
- 제목 정렬 성능을 위해 `idx_books_title_sort_key_created_at` 인덱스를 추가했습니다.

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] 전체 테스트 및 커버리지 검증 통과 확인 (`./gradlew clean test jacocoTestReport jacocoTestCoverageVerification`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 정렬용 키는 제목을 NFKC 정규화, 소문자 변환, 구두점 공백 처리, 숫자 20자리 패딩 방식으로 생성합니다.
- 예: `정렬-2`가 `정렬-10`보다 먼저 오도록 숫자 문자열 정렬 문제를 보정했습니다.
- 배포 시 Flyway가 `books.title_sort_key` 컬럼 추가 및 기존 데이터 보정을 수행합니다.

