### PR TITLE
[BE-122] Fix: 리뷰 soft delete 유니크 제약 수정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/Review.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/entity/Review.java
@@ -15,15 +15,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(
-    name = "reviews",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "uk_book_user_is_deleted", // 수정: 논리 삭제 충돌 해결을 위해 is_deleted 추가
-            columnNames = {"book_id", "user_id", "is_deleted"}
-        )
-    }
-)
+@Table(name = "reviews")
 public class Review extends BaseEntity {
 
   @Id

--- a/deokhugam/src/main/resources/db/migration/V4__replace_review_unique_constraint_with_partial_index.sql
+++ b/deokhugam/src/main/resources/db/migration/V4__replace_review_unique_constraint_with_partial_index.sql
@@ -1,0 +1,12 @@
+ALTER TABLE reviews
+    DROP CONSTRAINT IF EXISTS uk_book_user_is_deleted;
+
+ALTER TABLE reviews
+    DROP CONSTRAINT IF EXISTS uq_reviews_book_user_is_deleted;
+
+ALTER TABLE reviews
+    DROP CONSTRAINT IF EXISTS uq_reviews_book_user;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_reviews_active_book_user
+    ON reviews (book_id, user_id)
+    WHERE is_deleted = FALSE;

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/review/repository/ReviewRepositoryImplTest.java
@@ -109,4 +109,42 @@ public class ReviewRepositoryImplTest {
         s.likeCount() == 1L &&
         s.commentCount() == 1L);
   }
+
+  @Test
+  @DisplayName("성공: 같은 도서와 유저의 삭제된 리뷰 이력은 여러 개 저장할 수 있다")
+  void saveDeletedReviewHistories_Success() {
+    LocalDateTime now = LocalDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS);
+    Review deletedReview1 = Review.builder()
+        .user(user)
+        .book(book1)
+        .content("삭제된 리뷰 1")
+        .rating(3)
+        .build();
+    deletedReview1.delete();
+    ReflectionTestUtils.setField(deletedReview1, "createdAt", now);
+    ReflectionTestUtils.setField(deletedReview1, "updatedAt", now);
+
+    Review deletedReview2 = Review.builder()
+        .user(user)
+        .book(book1)
+        .content("삭제된 리뷰 2")
+        .rating(4)
+        .build();
+    deletedReview2.delete();
+    ReflectionTestUtils.setField(deletedReview2, "createdAt", now);
+    ReflectionTestUtils.setField(deletedReview2, "updatedAt", now);
+
+    em.persist(deletedReview1);
+    em.persist(deletedReview2);
+    em.flush();
+    em.clear();
+
+    List<Review> reviews = reviewRepository.findAll();
+
+    assertThat(reviews)
+        .filteredOn(review -> review.getBook().getId().equals(book1.getId()))
+        .filteredOn(review -> review.getUser().getId().equals(user.getId()))
+        .filteredOn(Review::isDeleted)
+        .hasSize(2);
+  }
 }


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion:

## 🛠️ 작업 내용

### 🐛 버그 수정
- 같은 유저가 같은 도서에 대해 리뷰를 삭제한 뒤 다시 작성하고 재삭제할 때 `uk_book_user_is_deleted` 유니크 제약 충돌이 발생하던 문제를 수정했습니다.
- 기존 `UNIQUE (book_id, user_id, is_deleted)` 제약이 삭제된 리뷰 이력까지 1개로 제한하던 문제를 제거했습니다.

### ✨ 기능 추가 / 구현
- 활성 리뷰에 대해서만 유저+도서 기준 1개를 허용하도록 PostgreSQL partial unique index를 추가했습니다.
- 삭제된 리뷰 이력은 여러 개 저장될 수 있도록 DB 제약을 변경했습니다.

### ♻️ 리팩토링
- `Review` 엔티티의 `@UniqueConstraint(book_id, user_id, is_deleted)` 설정을 제거했습니다.
- 유니크 제약 관리는 JPA 어노테이션이 아니라 Flyway 마이그레이션 기준으로 처리하도록 정리했습니다.

### ⚙️ 설정 변경
- Flyway 마이그레이션 `V4__replace_review_unique_constraint_with_partial_index.sql`을 추가했습니다.
- 기존 리뷰 유니크 제약을 제거하고 `ux_reviews_active_book_user` partial unique index를 생성하도록 변경했습니다.

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test --tests com.deokhugam.deokhugam_server.domain.review.repository.ReviewRepositoryImplTest`)
- [x] 전체 테스트 및 커버리지 검증 통과 확인 (`./gradlew clean test jacocoTestReport jacocoTestCoverageVerification`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [ ] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 운영 DB에서는 Flyway 적용 시 기존 `uk_book_user_is_deleted` 제약이 제거되고, 활성 리뷰만 제한하는 partial unique index가 생성됩니다.
- 도서 제목 정렬 브랜치도 `V4` 마이그레이션을 사용한 이력이 있어, 머지 순서에 따라 Flyway 버전 충돌이 발생하면 이 PR의 마이그레이션 버전을 `V5` 등으로 조정해야 합니다.

