### PR TITLE
[BE-123] Fix: 유저 삭제 감사 로그 추가

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -20,10 +20,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
@@ -125,7 +127,8 @@ public class UserServiceImpl implements UserService {
       .orElseThrow(() -> new DeokhugamException(USER_NOT_FOUND));
 
     user.delete();
-
+    log.info("User soft delete completed. requestUserId={}, targetUserId={}, deletedAt={}",
+        requestUserId, targetUserId, user.getDeletedAt());
   }
 
   @Override
@@ -138,6 +141,8 @@ public class UserServiceImpl implements UserService {
     }
 
     userRepository.deleteById(targetUserId);
+    log.info("User hard delete completed. requestUserId={}, targetUserId={}",
+        requestUserId, targetUserId);
   }
   private void validateOwner(UUID requestUserId, UUID targetUserId) {
     if (!requestUserId.equals(targetUserId)) {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
@@ -41,10 +41,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 @MockitoSettings(strictness = Strictness.LENIENT)
 class UserServiceTest {
   @Mock
@@ -229,7 +231,7 @@ class UserServiceTest {
 
   @Test
   @DisplayName("소프트 삭제 성공")
-  void deleteSoft_Success() {
+  void deleteSoft_Success(CapturedOutput output) {
     // given
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
@@ -238,12 +240,15 @@ class UserServiceTest {
 
     // then
     assertThat(user.isDeleted()).isTrue();
+    assertThat(output.getOut()).contains("User soft delete completed");
+    assertThat(output.getOut()).contains("requestUserId=" + requestUserId);
+    assertThat(output.getOut()).contains("targetUserId=" + userId);
     verify(userRepository).findById(userId);
   }
 
   @Test
   @DisplayName("물리 삭제 성공")
-  void deleteHard_Success() {
+  void deleteHard_Success(CapturedOutput output) {
     // given
     given(userRepository.existsById(userId)).willReturn(true);
     // when
@@ -251,6 +256,9 @@ class UserServiceTest {
     // then
     verify(userRepository).existsById(userId);
     verify(userRepository).deleteById(userId);
+    assertThat(output.getOut()).contains("User hard delete completed");
+    assertThat(output.getOut()).contains("requestUserId=" + requestUserId);
+    assertThat(output.getOut()).contains("targetUserId=" + userId);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion:

## 🛠️ 작업 내용

### 🐛 버그 수정
- 유저 논리 삭제/물리 삭제가 정상 처리되어도 AWS 로그에서 성공 여부를 확인할 수 없던 문제를 수정했습니다.

### ✨ 기능 추가 / 구현
- 유저 논리 삭제 성공 시 `requestUserId`, `targetUserId`, `deletedAt`이 포함된 감사 로그를 남기도록 추가했습니다.
- 유저 물리 삭제 성공 시 `requestUserId`, `targetUserId`가 포함된 감사 로그를 남기도록 추가했습니다.

### ♻️ 리팩토링
- `UserServiceImpl`에 SLF4J 기반 로깅을 적용했습니다.

### ⚙️ 설정 변경
- 없음

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test --tests com.deokhugam.deokhugam_server.domain.user.service.UserServiceTest`)
- [x] 전체 테스트 및 커버리지 검증 통과 확인 (`./gradlew clean test jacocoTestReport jacocoTestCoverageVerification`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 실패 로그는 기존 `GlobalExceptionHandler`에서 처리하므로, 이번 작업에서는 삭제 성공 로그만 추가했습니다.
- 로그에는 비밀번호, 토큰 등 민감 정보는 포함하지 않았습니다.
- S3 로그 적재는 기존 일별 파일 로그 업로드 스케줄에 따라 다음 적재 시점에 반영됩니다.


