### PR TITLE
[BE-RELEASE] 운영 배포 반영 v1.3.1

### DIFF
--- a/deokhugam/docs/ERD.md
+++ b/deokhugam/docs/ERD.md
@@ -1,7 +1,12 @@
 # ERD
 
 기준 파일:
-- `deokhugam/src/main/resources/schema.sql`
+- `deokhugam/src/main/resources/db/migration/V1__init_schema.sql`
+- `deokhugam/src/main/resources/db/migration/V2__repair_schema_to_match_entities.sql`
+- `deokhugam/src/main/resources/db/migration/V3__create_spring_batch_metadata_tables.sql`
+- `deokhugam/src/main/resources/db/migration/V4__add_book_title_sort_key.sql`
+- `deokhugam/src/main/resources/db/migration/V5__replace_review_unique_constraint_with_partial_index.sql`
+- `deokhugam/src/main/resources/db/migration/V7__rebuild_book_title_sort_key_character_groups.sql`
 - `deokhugam/src/main/resources/static/api.json`
 
 ```mermaid
@@ -20,6 +25,7 @@ erDiagram
     books {
         UUID id PK
         VARCHAR title
+        VARCHAR title_sort_key
         VARCHAR author
         TEXT description
         VARCHAR publisher
@@ -42,7 +48,6 @@ erDiagram
         INTEGER rating
         INTEGER like_count
         INTEGER comment_count
-        BOOLEAN liked_by_me_default
         BOOLEAN is_deleted
         TIMESTAMP deleted_at
         TIMESTAMP created_at
@@ -64,7 +69,6 @@ erDiagram
         UUID id PK
         UUID review_id FK
         UUID user_id FK
-        VARCHAR user_nickname
         TEXT content
         BOOLEAN is_deleted
         TIMESTAMP deleted_at
@@ -76,9 +80,9 @@ erDiagram
         UUID id PK
         UUID user_id FK
         UUID review_id FK
-        TEXT review_content
-        TEXT message
-        BOOLEAN confirmed
+        TEXT content
+        VARCHAR type
+        BOOLEAN is_read
         BOOLEAN is_deleted
         TIMESTAMP deleted_at
         TIMESTAMP created_at
@@ -88,11 +92,12 @@ erDiagram
     popular_books {
         UUID id PK
         UUID book_id FK
-        VARCHAR period
-        BIGINT rank
+        VARCHAR period_type
+        BIGINT rank_order
         DOUBLE score
         BIGINT review_count
         DOUBLE rating
+        DATE calculated_date
         BOOLEAN is_deleted
         TIMESTAMP deleted_at
         TIMESTAMP created_at
@@ -102,16 +107,12 @@ erDiagram
     popular_reviews {
         UUID id PK
         UUID review_id FK
-        UUID book_id FK
-        UUID user_id FK
-        VARCHAR user_nickname
-        TEXT review_content
-        DOUBLE review_rating
-        VARCHAR period
-        BIGINT rank
+        VARCHAR period_type
+        BIGINT rank_order
         DOUBLE score
         BIGINT like_count
         BIGINT comment_count
+        DATE calculated_date
         BOOLEAN is_deleted
         TIMESTAMP deleted_at
         TIMESTAMP created_at
@@ -121,12 +122,13 @@ erDiagram
     power_users {
         UUID id PK
         UUID user_id FK
-        VARCHAR period
-        BIGINT rank
+        VARCHAR period_type
+        BIGINT rank_order
         DOUBLE score
         DOUBLE review_score_sum
         BIGINT like_count
         BIGINT comment_count
+        DATE calculated_date
         BOOLEAN is_deleted
         TIMESTAMP deleted_at
         TIMESTAMP created_at
@@ -143,8 +145,6 @@ erDiagram
     reviews ||--o{ notifications : triggers
     books ||--o{ popular_books : ranks
     reviews ||--o{ popular_reviews : ranks
-    books ||--o{ popular_reviews : belongs_to
-    users ||--o{ popular_reviews : authored_by
     users ||--o{ power_users : ranks
 ```
 
@@ -152,4 +152,7 @@ erDiagram
 
 - `popular_books`, `popular_reviews`, `power_users`는 집계/랭킹 스냅샷 테이블입니다.
 - 모든 영속 테이블에 `is_deleted`, `deleted_at`을 포함해 soft delete 규칙을 반영했습니다.
+- `books.title_sort_key`는 제목 정렬 전용 컬럼입니다. 숫자, 영문, 한글, 기타 문자 그룹을 분리해 정렬하고, 기존 데이터는 Flyway V7에서 재계산합니다.
+- `reviews`는 활성 리뷰만 `(book_id, user_id)` 중복을 막는 부분 유니크 인덱스 `ux_reviews_active_book_user`를 사용합니다.
+- Spring Batch 메타테이블(`BATCH_*`)은 배치 실행 이력 관리용 시스템 테이블이라 도메인 ERD 관계도에서는 제외했습니다.
 - `NaverBookDto`, OCR 요청 스키마처럼 외부 조회/임시 입력 성격의 스키마는 ERD에서 제외했습니다.

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
@@ -38,7 +38,7 @@ public class Book extends BaseEntity {
   @Column(name = "title", nullable = false, length = 255)
   private String title;
 
-  @Column(name = "title_sort_key", nullable = false, length = 500)
+  @Column(name = "title_sort_key", nullable = false, length = 2048)
   private String titleSortKey;
 
   @Column(name = "author", nullable = false, length = 255)
@@ -139,29 +139,39 @@ public class Book extends BaseEntity {
     }
     matcher.appendTail(sortKey);
 
-    return normalizeHangulSyllables(sortKey.toString());
+    return normalizeSortCharacters(sortKey.toString());
   }
 
-  private static String normalizeHangulSyllables(String value) {
+  private static String normalizeSortCharacters(String value) {
     StringBuilder result = new StringBuilder();
 
     for (int i = 0; i < value.length(); i++) {
       char current = value.charAt(i);
-      if (current >= HANGUL_BASE && current <= HANGUL_END) {
+      if (Character.isDigit(current)) {
+        result.append('0').append(current);
+      } else if (isEnglishLetter(current)) {
+        result.append('1').append(current);
+      } else if (current >= HANGUL_BASE && current <= HANGUL_END) {
         int syllableIndex = current - HANGUL_BASE;
         int choseong = syllableIndex / (HANGUL_JUNG_COUNT * HANGUL_JONG_COUNT);
         int jungseong = (syllableIndex % (HANGUL_JUNG_COUNT * HANGUL_JONG_COUNT)) / HANGUL_JONG_COUNT;
         int jongseong = syllableIndex % HANGUL_JONG_COUNT;
-        result.append('k')
+        result.append('2')
           .append(twoDigit(choseong))
           .append(twoDigit(jungseong))
           .append(twoDigit(jongseong));
+      } else if (Character.isWhitespace(current)) {
+        result.append('3').append(' ');
       } else {
-        result.append(current);
+        result.append('9').append(current);
       }
     }
 
     return result.toString();
+  }
+
+  private static boolean isEnglishLetter(char value) {
+    return value >= 'a' && value <= 'z';
   }
 
   private static String twoDigit(int value) {

--- a/deokhugam/src/main/resources/db/migration/V7__rebuild_book_title_sort_key_character_groups.sql
+++ b/deokhugam/src/main/resources/db/migration/V7__rebuild_book_title_sort_key_character_groups.sql
@@ -1,0 +1,90 @@
+CREATE OR REPLACE FUNCTION deokhugam_title_sort_key_v3(input_title TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    source_text TEXT := regexp_replace(
+        regexp_replace(lower(btrim(coalesce(input_title, ''))), '[[:punct:]]+', ' ', 'g'),
+        '[[:space:]]+',
+        ' ',
+        'g'
+    );
+    converted_text TEXT := '';
+    numeric_normalized_text TEXT := '';
+    digit_buffer TEXT := '';
+    current_char TEXT;
+    code_point INTEGER;
+    syllable_index INTEGER;
+    choseong INTEGER;
+    jungseong INTEGER;
+    jongseong INTEGER;
+    index_value INTEGER;
+BEGIN
+    FOR index_value IN 1..char_length(source_text) LOOP
+        current_char := substr(source_text, index_value, 1);
+
+        IF current_char ~ '[0-9]' THEN
+            digit_buffer := digit_buffer || current_char;
+        ELSE
+            IF digit_buffer <> '' THEN
+                digit_buffer := regexp_replace(digit_buffer, '^0+(?!$)', '');
+                IF char_length(digit_buffer) < 20 THEN
+                    numeric_normalized_text := numeric_normalized_text || lpad(digit_buffer, 20, '0');
+                ELSE
+                    numeric_normalized_text := numeric_normalized_text || digit_buffer;
+                END IF;
+                digit_buffer := '';
+            END IF;
+
+            numeric_normalized_text := numeric_normalized_text || current_char;
+        END IF;
+    END LOOP;
+
+    IF digit_buffer <> '' THEN
+        digit_buffer := regexp_replace(digit_buffer, '^0+(?!$)', '');
+        IF char_length(digit_buffer) < 20 THEN
+            numeric_normalized_text := numeric_normalized_text || lpad(digit_buffer, 20, '0');
+        ELSE
+            numeric_normalized_text := numeric_normalized_text || digit_buffer;
+        END IF;
+    END IF;
+
+    FOR index_value IN 1..char_length(numeric_normalized_text) LOOP
+        current_char := substr(numeric_normalized_text, index_value, 1);
+        code_point := ascii(current_char);
+
+        IF current_char ~ '[0-9]' THEN
+            converted_text := converted_text || '0' || current_char;
+        ELSIF current_char ~ '[a-z]' THEN
+            converted_text := converted_text || '1' || current_char;
+        ELSIF code_point BETWEEN 44032 AND 55203 THEN
+            syllable_index := code_point - 44032;
+            choseong := syllable_index / (21 * 28);
+            jungseong := (syllable_index % (21 * 28)) / 28;
+            jongseong := syllable_index % 28;
+            converted_text := converted_text
+                || '2'
+                || lpad(choseong::TEXT, 2, '0')
+                || lpad(jungseong::TEXT, 2, '0')
+                || lpad(jongseong::TEXT, 2, '0');
+        ELSIF current_char ~ '[[:space:]]' THEN
+            converted_text := converted_text || '3 ';
+        ELSE
+            converted_text := converted_text || '9' || current_char;
+        END IF;
+    END LOOP;
+
+    RETURN btrim(converted_text);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+ALTER TABLE books
+    ALTER COLUMN title_sort_key TYPE VARCHAR(2048);
+
+UPDATE books
+SET title_sort_key = deokhugam_title_sort_key_v3(title);
+
+DROP INDEX IF EXISTS idx_books_title_sort_key_created_at;
+
+CREATE INDEX IF NOT EXISTS idx_books_title_sort_key_created_at
+    ON books (title_sort_key, created_at DESC);
+
+DROP FUNCTION IF EXISTS deokhugam_title_sort_key_v3(TEXT);

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/entity/BookEntityTest.java
@@ -22,7 +22,7 @@ class BookEntityTest {
     );
 
     assertThat(book.getTitle()).isEqualTo("클린 코드");
-    assertThat(book.getTitleSortKey()).isEqualTo("k151808k052004 k150800k031800");
+    assertThat(book.getTitleSortKey()).isEqualTo(Book.toTitleSortKey("클린 코드"));
     assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
     assertThat(book.getIsbn()).isEqualTo("9788966260959");
     assertThat(book.getPublisher()).isEqualTo("인사이트");
@@ -48,7 +48,7 @@ class BookEntityTest {
     );
 
     assertThat(book.getTitle()).isEqualTo("수정된 제목");
-    assertThat(book.getTitleSortKey()).isEqualTo("k091300k120421k031104 k120500k060801");
+    assertThat(book.getTitleSortKey()).isEqualTo(Book.toTitleSortKey("수정된 제목"));
     assertThat(book.getAuthor()).isEqualTo("수정된 저자");
     assertThat(book.getPublisher()).isEqualTo("수정된 출판사");
     assertThat(book.getDescription()).isEqualTo("수정된 설명");
@@ -64,7 +64,7 @@ class BookEntityTest {
     book.update(null, null, null, null, null, null);
 
     assertThat(book.getTitle()).isEqualTo("클린 코드");
-    assertThat(book.getTitleSortKey()).isEqualTo("k151808k052004 k150800k031800");
+    assertThat(book.getTitleSortKey()).isEqualTo(Book.toTitleSortKey("클린 코드"));
     assertThat(book.getAuthor()).isEqualTo("로버트 마틴");
     assertThat(book.getPublisher()).isEqualTo("인사이트");
     assertThat(book.getDescription()).isEqualTo("좋은 코드 작성법");
@@ -86,10 +86,19 @@ class BookEntityTest {
   @Test
   @DisplayName("정렬용 제목 키는 대소문자, 구두점, 숫자 자릿수를 정규화한다")
   void toTitleSortKey_mixedTitle_success() {
-    assertThat(Book.toTitleSortKey(" Book-10 ")).isEqualTo("book 00000000000000000010");
-    assertThat(Book.toTitleSortKey("book 2")).isEqualTo("book 00000000000000000002");
-    assertThat(Book.toTitleSortKey("정렬-Banana")).isEqualTo("k120421k050608 banana");
-    assertThat(Book.toTitleSortKey("내 강아지")).isEqualTo("k020100 k000021k110000k122000");
+    assertThat(Book.toTitleSortKey(" Book-10 ")).isEqualTo(Book.toTitleSortKey("book 10"));
+    assertThat(Book.toTitleSortKey("book 2")).isLessThan(Book.toTitleSortKey("Book-10"));
+    assertThat(Book.toTitleSortKey("정렬-Banana")).contains("1b1a1n1a1n1a");
+    assertThat(Book.toTitleSortKey("내 강아지")).startsWith("2020100");
+  }
+
+  @Test
+  @DisplayName("정렬용 제목 키는 숫자, 영문, 한글, 기타 문자를 그룹 순서대로 정렬한다")
+  void toTitleSortKey_characterGroupOrder_success() {
+    assertThat(Book.toTitleSortKey("1984")).startsWith("0");
+    assertThat(Book.toTitleSortKey("Money")).startsWith("1");
+    assertThat(Book.toTitleSortKey("총 균 쇠")).startsWith("2");
+    assertThat(Book.toTitleSortKey("☆별")).startsWith("9");
   }
 
   private Book createBook() {

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepositoryCustomImplTest.java
@@ -273,6 +273,97 @@ class BookRepositoryCustomImplTest {
   }
 
   @Test
+  @DisplayName("성공: 숫자, 영문, 한글이 섞인 제목을 문자 그룹과 알파벳순으로 조회한다")
+  void searchBooks_OrderByTitleSortKeyMixedCharacterGroups_Success() {
+    persistBook(
+      "The Pragmatic Programmer",
+      "alphabet-tester",
+      "9790000000101",
+      LocalDate.of(2024, 1, 1),
+      BASE_TIME.plusDays(1)
+    );
+    persistBook(
+      "Moneyball",
+      "alphabet-tester",
+      "9790000000102",
+      LocalDate.of(2024, 1, 2),
+      BASE_TIME.plusDays(2)
+    );
+    persistBook(
+      "Apple Design",
+      "alphabet-tester",
+      "9790000000103",
+      LocalDate.of(2024, 1, 3),
+      BASE_TIME.plusDays(3)
+    );
+    persistBook(
+      "가나다 책",
+      "alphabet-tester",
+      "9790000000104",
+      LocalDate.of(2024, 1, 4),
+      BASE_TIME.plusDays(4)
+    );
+    persistBook(
+      "10 Rules",
+      "alphabet-tester",
+      "9790000000105",
+      LocalDate.of(2024, 1, 5),
+      BASE_TIME.plusDays(5)
+    );
+    persistBook(
+      "초보 개발",
+      "alphabet-tester",
+      "9790000000106",
+      LocalDate.of(2024, 1, 6),
+      BASE_TIME.plusDays(6)
+    );
+
+    em.flush();
+    em.clear();
+
+    BookSearchRequest ascRequest = new BookSearchRequest(
+      "alphabet-tester",
+      "title",
+      "ASC",
+      null,
+      null,
+      10
+    );
+    BookSearchRequest descRequest = new BookSearchRequest(
+      "alphabet-tester",
+      "title",
+      "DESC",
+      null,
+      null,
+      10
+    );
+
+    List<BookSearchQueryDto> ascResult = bookRepository.searchBooks(ascRequest);
+    List<BookSearchQueryDto> descResult = bookRepository.searchBooks(descRequest);
+
+    assertThat(ascResult)
+      .extracting(BookSearchQueryDto::title)
+      .containsExactly(
+        "10 Rules",
+        "Apple Design",
+        "Moneyball",
+        "The Pragmatic Programmer",
+        "가나다 책",
+        "초보 개발"
+      );
+    assertThat(descResult)
+      .extracting(BookSearchQueryDto::title)
+      .containsExactly(
+        "초보 개발",
+        "가나다 책",
+        "The Pragmatic Programmer",
+        "Moneyball",
+        "Apple Design",
+        "10 Rules"
+      );
+  }
+
+  @Test
   @DisplayName("성공: 한글 제목을 가나다순 정렬키 기준으로 조회한다")
   void searchBooks_OrderByTitleSortKeyKoreanTitles_Success() {
     persistBook(


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/v1-3-1-3566e443c288801796fcece2a9a5dc4e?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- 도서 제목순 정렬에서 영문 제목 일부가 한글 제목과 섞여 기대 순서와 다르게 노출되는 문제 수정
- 제목 정렬키에 문자 그룹 정책 적용
- 숫자, 영문, 한글, 기타 문자 기준 정렬 순서 보정

### ✨ 기능 추가 / 구현
- 기존 운영 도서 데이터의 `title_sort_key` 재계산을 위한 Flyway V7 마이그레이션 추가
- 숫자/영문/한글 혼합 제목 ASC/DESC 정렬 검증 테스트 추가

### ♻️ 리팩토링
- `title_sort_key` 생성 기준을 문자 그룹 기반 정렬 정책으로 정리
- ERD 문서를 운영 Flyway 스키마 기준으로 최신화

### ⚙️ 설정 변경
- `books.title_sort_key` 길이를 `VARCHAR(500)`에서 `VARCHAR(2048)`로 확장

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 제목 정렬 ASC 기준은 `숫자 → 영문 → 한글 → 기타` 순서로 동작
- DESC 기준은 ASC의 역순으로 동작
- 배포 후 Flyway `V7__rebuild_book_title_sort_key_character_groups.sql` 적용 여부 확인 필요
- 배포 후 도서 목록에서 `orderBy=title&direction=ASC/DESC` 기준 정렬 확인 필요
