### PR TITLE
[BE-128] fix: login 시 탈퇴유저 필터링

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/entity/User.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "users")
@@ -16,6 +17,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLRestriction("is_deleted = false")
 public class User extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)


### PR DESCRIPTION

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion: https://www.notion.so/login-3566e443c28880ecbb81f480b0bc5f35?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

### 🐛 버그 수정
- 탈퇴 처리(Soft Delete)된 사용자가 여전히 로그인할 수 있던 문제 수정
- `User` 엔티티에 `@SQLRestriction("is_deleted = false")` 추가하여 전역 필터 적용

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] API 동작 확인 (탈퇴 후 해당 이메일로 로그인 시도 시 실패 확인)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->
- `BaseEntity`의 `isDeleted` 필드를 활용하여 소프트 델리트된 회원이 모든 조회 로직에서 자동으로 제외되도록 조치했습니다.
