### PR TITLE
[BE-128] fix: 도서 삭제 후 ISBN 재등록 허용

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/entity/Book.java
@@ -44,7 +44,7 @@ public class Book extends BaseEntity {
   @Column(name = "author", nullable = false, length = 255)
   private String author;
 
-  @Column(name = "isbn", nullable = false, unique = true, length = 20)
+  @Column(name = "isbn", nullable = false, length = 20)
   private String isbn;
 
   @Column(name = "publisher", length = 255)

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/repository/BookRepository.java
@@ -11,5 +11,5 @@ public interface BookRepository extends JpaRepository<Book, UUID>, BookRepositor
 
   Optional<Book> findByIsbnAndIsDeletedFalse(String isbn);
 
-  boolean existsByIsbn(String isbn);
+  boolean existsByIsbnAndIsDeletedFalse(String isbn);
 }

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImpl.java
@@ -217,7 +217,7 @@ public class BookServiceImpl implements BookService {
   }
 
   private void validateDuplicateIsbn(String isbn) {
-    if (bookRepository.existsByIsbn(isbn)) {
+    if (bookRepository.existsByIsbnAndIsDeletedFalse(isbn)) {
       throw new DeokhugamException(ErrorCode.DUPLICATE_ISBN);
     }
   }

--- a/deokhugam/src/main/resources/db/migration/V8__replace_book_isbn_unique_constraint_with_partial_index.sql
+++ b/deokhugam/src/main/resources/db/migration/V8__replace_book_isbn_unique_constraint_with_partial_index.sql
@@ -1,0 +1,9 @@
+ALTER TABLE books
+    DROP CONSTRAINT IF EXISTS uq_books_isbn;
+
+ALTER TABLE books
+    DROP CONSTRAINT IF EXISTS uk_books_isbn;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_books_active_isbn
+    ON books (isbn)
+    WHERE is_deleted = FALSE;

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/book/service/BookServiceImplTest.java
@@ -120,7 +120,7 @@ class BookServiceImplTest {
       now
     );
 
-    when(bookRepository.existsByIsbn("9788912345678")).thenReturn(false);
+    when(bookRepository.existsByIsbnAndIsDeletedFalse("9788912345678")).thenReturn(false);
     when(bookRepository.save(any(Book.class))).thenReturn(savedBook);
     when(savedBook.getId()).thenReturn(bookId);
     when(bookRepository.findBookDetail(bookId)).thenReturn(queryDto);
@@ -186,7 +186,7 @@ class BookServiceImplTest {
       now
     );
 
-    when(bookRepository.existsByIsbn("9788912345678")).thenReturn(false);
+    when(bookRepository.existsByIsbnAndIsDeletedFalse("9788912345678")).thenReturn(false);
     when(s3Util.upload(thumbnailImage, "books")).thenReturn(thumbnailUrl);
     when(bookRepository.save(any(Book.class))).thenReturn(savedBook);
     when(savedBook.getId()).thenReturn(bookId);
@@ -212,7 +212,7 @@ class BookServiceImplTest {
       LocalDate.of(2024, 1, 1)
     );
 
-    when(bookRepository.existsByIsbn("9788912345678")).thenReturn(true);
+    when(bookRepository.existsByIsbnAndIsDeletedFalse("9788912345678")).thenReturn(true);
 
     DeokhugamException exception = assertThrows(DeokhugamException.class, () ->
       bookService.createBook(request, null)


### PR DESCRIPTION
## 🛠️ 작업 내용

### 🐛 버그 수정
- 논리 삭제된 도서의 ISBN이 계속 중복으로 판정되어 같은 ISBN 도서를 재등록할 수 없던 문제 수정
- 도서 등록 시 ISBN 중복 검사를 전체 도서 기준이 아닌 활성 도서 기준으로 변경
- DB의 ISBN 유니크 제약을 활성 도서 기준 partial unique index로 변경

### ✨ 기능 추가 / 구현
- Flyway V8 마이그레이션 추가
- `books.isbn` 전체 unique 제약 제거
- `is_deleted = false` 조건의 `ux_books_active_isbn` unique index 추가

### ♻️ 리팩토링
- `Book` 엔티티의 `isbn` 필드에서 JPA `unique = true` 제거
- `BookRepository` 중복 검사 메서드를 `existsByIsbnAndIsDeletedFalse`로 정리

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 기존 `uq_books_isbn` 제약이 운영 DB에 남아 있으면 논리 삭제 도서도 ISBN을 계속 점유하므로 재등록이 불가능
- V8 마이그레이션 적용 후에는 활성 도서끼리만 ISBN 중복을 차단
- 논리 삭제된 도서와 동일 ISBN의 신규 도서 등록 가능
