### PR TITLE
[BE-129] fix: 탈퇴회원 로그인 및 대시보드 정합성 문제 해결

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/entity/User.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/entity/User.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "users")
@@ -17,7 +16,6 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@SQLRestriction("is_deleted = false")
 public class User extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -57,9 +57,10 @@ public class UserServiceImpl implements UserService {
   @Override
   public UserDto login(UserLoginRequest request) {
     return userRepository.findByEmail(request.email())
-        .filter(u -> passwordEncoder.matches(request.password(), u.getPassword()))
-        .map(userMapper::toDto)
-        .orElseThrow(() -> new DeokhugamException(LOGIN_FAILED));
+      .filter(u -> !u.isDeleted())
+      .filter(u -> passwordEncoder.matches(request.password(), u.getPassword()))
+      .map(userMapper::toDto)
+      .orElseThrow(() -> new DeokhugamException(LOGIN_FAILED));
   }
 
   @Override


### PR DESCRIPTION

## 🔗 Notion Task 링크
<!-- Task Tracker의 해당 항목 URL을 첨부해주세요 -->
- Notion: https://www.notion.so/3566e443c28880698ae7c5a4702a1b9b?source=copy_link

## 🛠️ 작업 내용
<!-- 변경 사항 유형에 해당하는 항목만 작성해주세요 -->

### 🐛 버그 수정
- 회원 탈퇴(Soft Delete) 완료 후에도 기존 계정으로 로그인이 가능한 보안 취약점 해결

### ♻️ 리팩토링
- 로그인 로직(`UserServiceImpl`)에 탈퇴 여부 검증(`isDeleted`) 필터 추가
- 기존에 적용했던 `User` 엔티티의 `@SQLRestriction` 전역 설정 제거 (통계 데이터 정합성 유지 목적)

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [x] API 동작 확인 (탈퇴 회원 로그인 시도 시 `LOGIN_FAILED` 예외 발생 확인)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
<!-- 리뷰어가 알아야 할 배경 지식, 관련 문서, 특이사항 등 -->
- **문제 해결 배경**: 전역 필터(`@SQLRestriction`) 적용 시, 탈퇴한 회원의 기록을 포함해야 하는 '인기 리뷰 점수 합산' 및 '대시보드 통계' 쿼리에서 유저 조인이 실패하여 런타임 오류가 발생함.
- **조치 사항**: 전역 필터를 제거하여 시스템 통계 및 대시보드 로직의 데이터 정합성을 복구하고, 시스템 접근 입구인 `login` 메서드에서만 `isDeleted` 상태를 체크하도록 변경하여 보안과 기능성을 모두 확보함.
