### PR TITLE
[BE-129] fix: 탈퇴 유저 로그인 필터 범위 조정

### DIFF
--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, UUID>, UserRepositoryCustom {
   Optional<User> findByEmail(String email);
 
+  Optional<User> findByEmailAndIsDeletedFalse(String email);
+
   Optional<User> findByIdAndIsDeletedFalse(UUID id);
 
   boolean existsByEmail(String email);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -56,8 +56,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public UserDto login(UserLoginRequest request) {
-    return userRepository.findByEmail(request.email())
-      .filter(u -> !u.isDeleted())
+    return userRepository.findByEmailAndIsDeletedFalse(request.email())
       .filter(u -> passwordEncoder.matches(request.password(), u.getPassword()))
       .map(userMapper::toDto)
       .orElseThrow(() -> new DeokhugamException(LOGIN_FAILED));

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
@@ -124,7 +124,7 @@ class UserServiceTest {
     // given
     UserLoginRequest request = new UserLoginRequest(TEST_EMAIL, RAW_PASSWORD);
 
-    given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(user));
+    given(userRepository.findByEmailAndIsDeletedFalse(TEST_EMAIL)).willReturn(Optional.of(user));
     given(passwordEncoder.matches(RAW_PASSWORD, user.getPassword())).willReturn(true);
     given(userMapper.toDto(user)).willReturn(
         new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now())
@@ -137,7 +137,7 @@ class UserServiceTest {
     assertThat(result.id()).isEqualTo(userId);
     assertThat(result.email()).isEqualTo(TEST_EMAIL);
 
-    verify(userRepository).findByEmail(TEST_EMAIL);
+    verify(userRepository).findByEmailAndIsDeletedFalse(TEST_EMAIL);
     verify(passwordEncoder).matches(RAW_PASSWORD, user.getPassword());
   }
 
@@ -148,7 +148,7 @@ class UserServiceTest {
     String wrongPassword = "wrong_password";
     UserLoginRequest request = new UserLoginRequest(TEST_EMAIL, wrongPassword);
 
-    given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(user));
+    given(userRepository.findByEmailAndIsDeletedFalse(TEST_EMAIL)).willReturn(Optional.of(user));
     given(passwordEncoder.matches(wrongPassword, user.getPassword())).willReturn(false);
 
     // when & then
@@ -156,6 +156,22 @@ class UserServiceTest {
         .isInstanceOf(DeokhugamException.class)
         .hasMessage(ErrorCode.LOGIN_FAILED.getMessage());
 
+    verify(userMapper, never()).toDto(any());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 탈퇴 사용자는 조회 대상에서 제외")
+  void login_Fail_DeletedUser() {
+    // given
+    UserLoginRequest request = new UserLoginRequest(TEST_EMAIL, RAW_PASSWORD);
+    given(userRepository.findByEmailAndIsDeletedFalse(TEST_EMAIL)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.login(request))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.LOGIN_FAILED.getMessage());
+
+    verify(passwordEncoder, never()).matches(anyString(), anyString());
     verify(userMapper, never()).toDto(any());
   }
 


### PR DESCRIPTION
## 🛠️ 작업 내용

### 🐛 버그 수정
- 탈퇴 유저 로그인 차단 로직을 로그인 조회 쿼리 기준으로 조정
- `User` 전역 필터 방식 대신 로그인 전용 활성 유저 조회 방식으로 변경
- 탈퇴 유저 연관 데이터가 인기리뷰, 리뷰, 댓글 조회에 영향을 주지 않도록 조회 범위 분리

### ✨ 기능 추가 / 구현
- `findByEmailAndIsDeletedFalse` Repository 메서드 추가
- 탈퇴 유저 로그인 실패 케이스 테스트 추가

### ♻️ 리팩토링
- 로그인 로직에서 `findByEmail()` 후 `isDeleted`를 필터링하던 방식을 Repository 쿼리 조건으로 정리


## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [ ] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- 탈퇴 유저 로그인 차단은 로그인 정책에만 필요한 조건이므로 `User` 엔티티 전역 필터가 아닌 Repository 조회 조건으로 처리
- 전역 필터를 적용하면 탈퇴 유저가 작성한 기존 리뷰/댓글/인기리뷰 연관 조회까지 영향을 받을 수 있어 범위를 분리
- 전체 테스트 및 Jacoco 커버리지 검증 통과 확인
