### PR TITLE
[BE-RELEASE] 운영 배포 반영 v1.3.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,6 +48,13 @@ jobs:
         env:
           SPRING_PROFILES_ACTIVE: test
 
+      - name: Codecov 업로드
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: deokhugam/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+
   deploy:
     name: Deploy to ECS
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 덕후감은 도서, 리뷰, 댓글, 알림, 인기 랭킹을 관리하는 Spring Boot 기반 백엔드 서버입니다.
 로컬 개발은 H2로 바로 실행할 수 있고, 운영 배포는 GitHub Actions를 통해 ECR 이미지를 빌드한 뒤 AWS ECS EC2 서비스로 배포합니다.
 
+## 구현 홈페이지
+
+- 서비스 URL: http://deokhugam-alb-444789430.ap-northeast-2.elb.amazonaws.com/
+
 ## 기술 스택
 
 | 구분 | 기술 |

--- a/deokhugam/Dockerfile
+++ b/deokhugam/Dockerfile
@@ -1,18 +1,19 @@
 # Stage 1: Build
-FROM gradle:8-jdk17-jammy AS builder
+FROM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /app
 
-# 의존성 캐시를 위해 gradle 설정 파일 먼저 복사
+# CI/CD와 동일한 Gradle Wrapper 기준으로 빌드한다.
 COPY build.gradle settings.gradle ./
-COPY gradle ./gradle
+COPY gradlew ./
+COPY gradle ./gradle/
 
 # 의존성 미리 다운로드 (캐시 레이어)
-RUN gradle dependencies --no-daemon || true
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
 
 # 소스 코드 복사 후 빌드 (테스트 제외)
 COPY src ./src
-RUN gradle bootJar --no-daemon -x test
+RUN ./gradlew bootJar --no-daemon -x test
 
 # Stage 2: Run
 FROM eclipse-temurin:17-jre-jammy AS runner

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/entity/User.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/entity/User.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "users")
@@ -17,7 +16,6 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@SQLRestriction("is_deleted = false")
 public class User extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepository.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/repository/UserRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, UUID>, UserRepositoryCustom {
   Optional<User> findByEmail(String email);
 
+  Optional<User> findByEmailAndIsDeletedFalse(String email);
+
   Optional<User> findByIdAndIsDeletedFalse(UUID id);
 
   boolean existsByEmail(String email);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceImpl.java
@@ -56,10 +56,10 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public UserDto login(UserLoginRequest request) {
-    return userRepository.findByEmail(request.email())
-        .filter(u -> passwordEncoder.matches(request.password(), u.getPassword()))
-        .map(userMapper::toDto)
-        .orElseThrow(() -> new DeokhugamException(LOGIN_FAILED));
+    return userRepository.findByEmailAndIsDeletedFalse(request.email())
+      .filter(u -> passwordEncoder.matches(request.password(), u.getPassword()))
+      .map(userMapper::toDto)
+      .orElseThrow(() -> new DeokhugamException(LOGIN_FAILED));
   }
 
   @Override

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/user/service/UserServiceTest.java
@@ -124,7 +124,7 @@ class UserServiceTest {
     // given
     UserLoginRequest request = new UserLoginRequest(TEST_EMAIL, RAW_PASSWORD);
 
-    given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(user));
+    given(userRepository.findByEmailAndIsDeletedFalse(TEST_EMAIL)).willReturn(Optional.of(user));
     given(passwordEncoder.matches(RAW_PASSWORD, user.getPassword())).willReturn(true);
     given(userMapper.toDto(user)).willReturn(
         new UserDto(userId, TEST_EMAIL, TEST_NICKNAME, LocalDateTime.now())
@@ -137,7 +137,7 @@ class UserServiceTest {
     assertThat(result.id()).isEqualTo(userId);
     assertThat(result.email()).isEqualTo(TEST_EMAIL);
 
-    verify(userRepository).findByEmail(TEST_EMAIL);
+    verify(userRepository).findByEmailAndIsDeletedFalse(TEST_EMAIL);
     verify(passwordEncoder).matches(RAW_PASSWORD, user.getPassword());
   }
 
@@ -148,7 +148,7 @@ class UserServiceTest {
     String wrongPassword = "wrong_password";
     UserLoginRequest request = new UserLoginRequest(TEST_EMAIL, wrongPassword);
 
-    given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(user));
+    given(userRepository.findByEmailAndIsDeletedFalse(TEST_EMAIL)).willReturn(Optional.of(user));
     given(passwordEncoder.matches(wrongPassword, user.getPassword())).willReturn(false);
 
     // when & then
@@ -156,6 +156,22 @@ class UserServiceTest {
         .isInstanceOf(DeokhugamException.class)
         .hasMessage(ErrorCode.LOGIN_FAILED.getMessage());
 
+    verify(userMapper, never()).toDto(any());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 탈퇴 사용자는 조회 대상에서 제외")
+  void login_Fail_DeletedUser() {
+    // given
+    UserLoginRequest request = new UserLoginRequest(TEST_EMAIL, RAW_PASSWORD);
+    given(userRepository.findByEmailAndIsDeletedFalse(TEST_EMAIL)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.login(request))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.LOGIN_FAILED.getMessage());
+
+    verify(passwordEncoder, never()).matches(anyString(), anyString());
     verify(userMapper, never()).toDto(any());
   }
 


### PR DESCRIPTION
## 🔗 Notion Task 링크
- Notion: https://www.notion.so/v1-3-2-3576e443c288805aa86cc8b00dc01e2f?source=copy_link

## 🛠️ 작업 내용

### 🐛 버그 수정
- 탈퇴 유저 로그인 차단 로직을 로그인 조회 정책으로 분리
- 탈퇴 유저 전역 필터 적용으로 인해 인기리뷰, 리뷰, 댓글 조회에 영향을 줄 수 있는 구조 정리
- 인기리뷰 전체/월간/주간 조회 시 탈퇴 유저 연관 데이터로 인해 500 오류가 발생할 수 있는 원인 제거

### ✨ 기능 추가 / 구현
- 활성 유저 로그인 조회용 `findByEmailAndIsDeletedFalse` Repository 메서드 추가
- 탈퇴 유저 로그인 실패 케이스 테스트 추가

### ♻️ 리팩토링
- 로그인 로직에서 `findByEmail()` 후 `isDeleted`를 애플리케이션 레벨에서 필터링하던 방식을 Repository 쿼리 조건으로 정리
- 유저 삭제 상태 정책을 로그인과 일반 조회/연관 조회로 분리

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-{ID}] 작업 제목`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [ ] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- `User` 엔티티 전역 필터 방식은 탈퇴 유저가 작성한 기존 리뷰/댓글/인기리뷰 조회까지 영향을 줄 수 있어 사용하지 않음
- 탈퇴 유저 로그인 차단은 로그인 조회 쿼리에서만 `is_deleted = false` 조건을 적용하는 방식으로 제한
- 전체 테스트 및 Jacoco 커버리지 검증 통과 확인


