### PR TITLE
[BE-DOCS] README 소개 문서 정리 및 문서 변경 워크플로우 제외 설정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,10 @@ name: CD
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'deokhugam/docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [ dev, main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'deokhugam/docs/**'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,139 +1,73 @@
-# 덕후감 서버 (Deokhugam Server)
+# 덕후감 서버
 
-[![CI](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/actions/workflows/ci.yml/badge.svg)](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/sprint-sb09-part03-team02/sb09-deokhugam-team02/graph/badge.svg)](https://codecov.io/gh/sprint-sb09-part03-team02/sb09-deokhugam-team02)
+[![CI](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sprint-sb09-part03-team02/sb09-deokhugam-team02/actions/workflows/ci.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/sprint-sb09-part03-team02/sb09-deokhugam-team02/branch/main/graph/badge.svg)](https://codecov.io/gh/sprint-sb09-part03-team02/sb09-deokhugam-team02/tree/main)
+![Java](https://img.shields.io/badge/Java-17-007396)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.x-6DB33F)
+![AWS](https://img.shields.io/badge/AWS-ECS%20EC2-FF9900)
 
-덕후감은 도서, 리뷰, 댓글, 알림, 인기 랭킹을 관리하는 Spring Boot 기반 백엔드 서버입니다.
-로컬 개발은 H2로 바로 실행할 수 있고, 운영 배포는 GitHub Actions를 통해 ECR 이미지를 빌드한 뒤 AWS ECS EC2 서비스로 배포합니다.
+덕후감은 도서 검색, 리뷰, 댓글, 알림, 인기 랭킹을 제공하는 도서 리뷰 플랫폼 백엔드입니다.
 
-## 구현 홈페이지
+## 서비스
 
-- 서비스 URL: http://deokhugam-alb-444789430.ap-northeast-2.elb.amazonaws.com/
+- 구현 홈페이지: http://deokhugam-alb-444789430.ap-northeast-2.elb.amazonaws.com/
+- 헬스 체크: `/actuator/health`
+- Swagger UI: `/swagger-ui/index.html`
+
+## 주요 기능
+
+| 구분 | 내용 |
+| --- | --- |
+| 도서 | 도서 등록, 수정, 삭제, 검색, 제목 정렬, ISBN OCR 추출, Naver Book API 연동 |
+| 리뷰 | 리뷰 작성, 수정, 삭제, 좋아요, 인기 리뷰 조회 |
+| 댓글 | 댓글 작성, 수정, 삭제, 리뷰 댓글 수 갱신 |
+| 알림 | 이벤트 기반 알림 생성, 조회, 읽음 처리 |
+| 랭킹 | Spring Batch 기반 인기 도서, 인기 리뷰, 파워 유저 집계 |
+| 운영 | 요청 추적 로그, CloudWatch Logs, S3 로그 적재, Actuator 메트릭 |
 
 ## 기술 스택
 
 | 구분 | 기술 |
 | --- | --- |
-| Backend | Java 17, Spring Boot 3.5.x, Spring Security, Spring Batch, Spring Actuator |
-| Database | PostgreSQL, H2(local/test), JPA, QueryDSL 5.1.0, Flyway |
-| Mapping / Validation | MapStruct 1.6.2, Bean Validation, Lombok |
-| Infra | AWS ECS EC2, ECR, RDS PostgreSQL, S3, CloudWatch Logs, Secrets Manager |
-| Test / Quality | JUnit5, Mockito, Spring Batch Test, JaCoCo, Codecov |
-| CI/CD | GitHub Actions |
+| Backend | Java 17, Spring Boot, Spring Security, Spring Batch, Spring Actuator |
+| Database | PostgreSQL, H2, JPA, QueryDSL, Flyway |
+| Infra | AWS ECS EC2, ALB, ECR, RDS, S3, CloudWatch Logs, Secrets Manager |
+| Test / CI/CD | JUnit5, Mockito, JaCoCo, Codecov, GitHub Actions |
 
-## 실행 방법
+## 아키텍처
 
-### 로컬 H2 실행
+```mermaid
+flowchart LR
+    Client["Client"] --> ALB["ALB"]
+    ALB --> ECS["ECS EC2"]
+    ECS --> RDS["RDS PostgreSQL"]
+    ECS --> S3["S3"]
+    ECS --> CW["CloudWatch Logs"]
+    CW --> Lambda["Lambda Exporter"]
+    Scheduler["EventBridge Scheduler"] --> Lambda
+    Lambda --> LogBucket["S3 Log Bucket"]
+```
 
-별도 DB 설정 없이 실행할 수 있는 기본 개발 방식입니다.
+## 실행
 
 ```bash
 cd deokhugam
 ./gradlew bootRun
 ```
 
-기본 프로필은 `local-h2`입니다.
+기본 로컬 프로필은 `local-h2`입니다. 운영 민감값은 AWS Secrets Manager와 GitHub Secrets에서 관리하며 저장소에 포함하지 않습니다.
 
-### 로컬 PostgreSQL 실행
-
-```bash
-cd deokhugam
-./gradlew bootRun --args='--spring.profiles.active=local'
-```
-
-민감값은 `application-local.yml`에 직접 커밋하지 않습니다. 필요한 경우 `application-local.yml.example`을 참고해 로컬 전용 파일로 관리합니다.
-
-## 테스트 및 커버리지
+## 테스트
 
 ```bash
 cd deokhugam
 ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification
 ```
 
-- 전체 테스트 커버리지 기준: **80% 이상**
-- JaCoCo HTML 리포트: `deokhugam/build/reports/jacoco/test/html/index.html`
-- CI에서 PR 생성 시 테스트, 커버리지 검증, Codecov 업로드를 수행합니다.
+프로젝트 전체 테스트 커버리지는 80% 이상을 기준으로 관리합니다.
 
-## 인증 방식
+## 문서
 
-현재 서버는 JWT 토큰 기반 인증이 아니라 API 요구사항에 맞춘 요청 헤더 기반 인증을 사용합니다.
-
-| 헤더 | 설명 |
-| --- | --- |
-| `Deokhugam-Request-User-ID` | 로그인 이후 요청에서 사용자 UUID를 전달하는 헤더 |
-| `X-Request-Id` | 서버가 요청별 추적을 위해 응답에 추가하는 request id |
-
-로그인, 회원가입, 홈/공개 조회 경로를 제외한 보호 API는 `Deokhugam-Request-User-ID` 헤더를 기준으로 사용자 컨텍스트를 구성합니다.
-
-## 주요 운영 기능
-
-### MDC 요청 로그
-
-모든 요청에 대해 `requestId`, `clientIp`를 MDC에 저장하고 로그 패턴에 포함합니다. 응답 헤더에는 `X-Request-Id`가 내려갑니다.
-
-### S3 날짜별 로그 적재
-
-운영 환경의 애플리케이션 로그는 ECS `awslogs` 드라이버를 통해 CloudWatch Logs에 먼저 수집됩니다. 이후 EventBridge Scheduler가 매일 Lambda를 실행하고, Lambda가 CloudWatch Logs Export Task를 생성해 전날 로그를 S3에 날짜별로 적재합니다.
-
-- 로그 원본: CloudWatch Logs `/ecs/deokhugam-task`
-- 자동 적재: EventBridge Scheduler → Lambda → CloudWatch Logs Export Task
-- S3 적재 경로: `cloudwatch/yyyy/MM/dd/`
-- 실행 기준: 매일 `01:10 Asia/Seoul`, 전날 `00:00:00~23:59:59 KST` 로그 export
-- 상세 설정: [AWS 배포 및 운영 가이드](deokhugam/docs/AWS_DEPLOYMENT.md)
-
-### Spring Batch 및 Actuator 메트릭
-
-인기 도서, 인기 리뷰, 파워 유저 랭킹과 알림 정리를 Spring Batch로 관리합니다. Batch 실행 결과는 Actuator 메트릭으로 확인할 수 있습니다.
-
-주요 메트릭:
-
-- `deokhugam.batch.job.completed`
-- `deokhugam.batch.job.duration`
-- `deokhugam.batch.job.last.duration.seconds`
-- `deokhugam.batch.job.last.success`
-
-### 도서 제목 정렬
-
-도서 목록의 `orderBy=title` 정렬은 `books.title_sort_key` 기준으로 처리합니다. 한글, 영문, 숫자, 대소문자가 섞인 제목도 안정적으로 정렬되도록 제목 저장/수정 시 정렬키를 생성하고, 운영 기존 데이터는 Flyway `V6__rebuild_book_title_sort_key.sql`로 재계산합니다.
-
-## CI/CD
-
-| Workflow | Trigger | 역할 |
-| --- | --- | --- |
-| `ci.yml` | `dev`, `main` 대상 PR | 테스트, 커버리지 검증, 리포트 업로드 |
-| `cd.yml` | `main` push, 수동 실행 | 테스트, Docker 이미지 빌드, ECR push, ECS 배포 |
-
-배포 흐름:
-
-```text
-PR -> CI 통과 -> dev -> main merge -> CD -> ECR push -> ECS service update
-```
-
-상세 GitHub Actions 설정은 [.github/workflows/README.md](.github/workflows/README.md)를 확인합니다.
-
-## AWS 구성 요약
-
-| 리소스 | 용도 |
-| --- | --- |
-| VPC / Subnet / Security Group | ECS, RDS 네트워크 격리 및 접근 제어 |
-| ECR | Docker 이미지 저장소 |
-| ECS EC2 | Spring Boot 애플리케이션 실행 |
-| RDS PostgreSQL | 운영 데이터베이스 및 Spring Batch 메타테이블 저장 |
-| S3 이미지 버킷 | 이미지/썸네일 저장 |
-| S3 로그 버킷 | CloudWatch Logs export 결과 날짜별 적재 |
-| Secrets Manager | DB, Naver API, OCR Space API 민감값 관리 |
-| CloudWatch Logs | ECS 컨테이너 표준 출력 로그 수집 및 S3 export 원본 |
-| Lambda / EventBridge Scheduler | 전날 CloudWatch Logs를 S3로 자동 export |
-
-자세한 구축/검증 절차는 [AWS 배포 및 운영 가이드](deokhugam/docs/AWS_DEPLOYMENT.md)를 확인합니다.
-
-## API 검증
-
-- 헬스 체크: `GET /actuator/health`
-- 메트릭 목록: `GET /actuator/metrics`
-- Swagger UI: `/swagger-ui/index.html`
-- Postman 시나리오: [POSTMAN_TEST_SCENARIOS.md](deokhugam/docs/POSTMAN_TEST_SCENARIOS.md)
-
-## 트러블슈팅 문서
-
-주요 배포 이슈와 해결 방식은 [AWS 배포 및 운영 가이드](deokhugam/docs/AWS_DEPLOYMENT.md)의 트러블슈팅 섹션에 정리되어 있습니다.
+- [AWS 배포 및 운영 가이드](deokhugam/docs/AWS_DEPLOYMENT.md)
+- [Postman 테스트 시나리오](deokhugam/docs/POSTMAN_TEST_SCENARIOS.md)
+- [GitHub Actions 문서](.github/workflows/README.md)


### PR DESCRIPTION
## 작업 내용

### ♻️ 리팩토링
- README를 소개 중심 문서로 축약
- 주요 기능, 기술 스택, 아키텍처, 실행/테스트 방법만 남기도록 정리

### ⚙️ 설정 변경
- 문서 변경만 포함된 PR에서는 CI가 실행되지 않도록 `paths-ignore` 추가
- 문서 변경만 포함된 main push에서는 CD가 실행되지 않도록 `paths-ignore` 추가
- 수동 배포를 위해 `workflow_dispatch`는 유지

## 테스트
- [ ] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava`)
- [ ] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test`)
- [ ] API 동작 확인 (Swagger 또는 직접 호출)

## 참고 사항
- 문서 및 GitHub Actions 트리거 조건 변경만 포함
- 애플리케이션 코드 변경 없음
- 이번 PR 자체는 workflow 파일 변경이 포함되어 CI가 실행될 수 있음
- 이후 README/docs 문서만 변경되는 PR 또는 main push부터 CI/CD가 스킵됨
