### PR TITLE
[BE-RELEASE] 운영 배포 반영 v1.3.4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,10 +3,6 @@ name: CD
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'deokhugam/docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [ dev, main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'deokhugam/docs/**'
 
 jobs:
   test:

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/comment/event/CommentCreatedEvent.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/comment/event/CommentCreatedEvent.java
@@ -5,5 +5,6 @@ import java.util.UUID;
 public record CommentCreatedEvent(
     UUID reviewId,
     UUID commentId,
-    UUID commentAuthorId
+    UUID commentAuthorId,
+    String commentAuthorNickname
 ) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/comment/service/CommentServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/comment/service/CommentServiceImpl.java
@@ -56,7 +56,8 @@ public class CommentServiceImpl implements CommentService {
     eventPublisher.publishEvent(new CommentCreatedEvent(
         savedComment.getReview().getId(),
         savedComment.getId(),
-        savedComment.getUserId()
+        savedComment.getUserId(),
+        user.getNickname()
     ));
 
     return commentMapper.toDto(savedComment, user.getNickname());

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListener.java
@@ -41,7 +41,7 @@ public class NotificationEventListener {
             event.reviewId(),
             reviewOwnerId,
             NotificationType.REVIEW_COMMENTED,
-            "회원님의 리뷰에 댓글이 달렸습니다."
+            String.format("%s님이 회원님의 리뷰에 댓글을 남겼습니다.", event.commentAuthorNickname())
         );
     }
 
@@ -56,7 +56,7 @@ public class NotificationEventListener {
             event.reviewId(),
             event.targetUserId(),
             NotificationType.REVIEW_LIKED,
-            "회원님의 리뷰에 좋아요가 달렸습니다."
+            String.format("%s님이 회원님의 리뷰에 좋아요를 눌렀습니다.", event.likerNickname())
         );
     }
 

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewLikedEvent.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/event/ReviewLikedEvent.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 public record ReviewLikedEvent(
     UUID reviewId,      // 좋아요가 달린 리뷰 ID
     UUID likerId,       // 좋아요를 누른 사용자 ID
+    String likerNickname,
     UUID targetUserId,  // 알림을 받을 리뷰 작성자 ID
     String reviewContent // 알림 메시지에 표시할 리뷰 내용 요약
 ) {}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/domain/review/service/ReviewServiceImpl.java
@@ -184,7 +184,7 @@ public class ReviewServiceImpl implements ReviewService {
       review.increaseLikeCount();
 
       eventPublisher.publishEvent(new ReviewLikedEvent(
-          reviewId, requestUserId, review.getUser().getId(), review.getContent()
+          reviewId, requestUserId, user.getNickname(), review.getUser().getId(), review.getContent()
       ));
 
       return new ReviewLikeDto(reviewId, requestUserId, true);

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/batch/ManualRankingBatchController.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/batch/ManualRankingBatchController.java
@@ -1,0 +1,100 @@
+package com.deokhugam.deokhugam_server.global.batch;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/internal/batches/ranking")
+@RequiredArgsConstructor
+public class ManualRankingBatchController {
+
+  private static final String INTERNAL_BATCH_KEY_HEADER = "X-Internal-Batch-Key";
+  private static final String ALL_PERIODS = "ALL";
+
+  private final JobLauncher jobLauncher;
+
+  @Qualifier("rankingJob")
+  private final Job rankingJob;
+
+  @Value("${deokhugam.batch.manual.key:}")
+  private String manualBatchKey;
+
+  @PostMapping
+  public ResponseEntity<ManualRankingBatchResponse> runRankingBatch(
+      @RequestHeader(INTERNAL_BATCH_KEY_HEADER) String requestKey,
+      @RequestParam(defaultValue = ALL_PERIODS) String period
+  ) {
+    validateInternalBatchKey(requestKey);
+
+    List<Period> periods = resolvePeriods(period);
+    List<ManualRankingBatchResult> results = new ArrayList<>();
+    long requestedAt = System.currentTimeMillis();
+
+    for (Period targetPeriod : periods) {
+      results.add(runJob(targetPeriod, requestedAt));
+    }
+
+    return ResponseEntity.ok(new ManualRankingBatchResponse(results));
+  }
+
+  private void validateInternalBatchKey(String requestKey) {
+    if (!StringUtils.hasText(manualBatchKey) || !manualBatchKey.equals(requestKey)) {
+      throw new DeokhugamException(ErrorCode.HANDLE_ACCESS_DENIED);
+    }
+  }
+
+  private List<Period> resolvePeriods(String period) {
+    if (ALL_PERIODS.equalsIgnoreCase(period)) {
+      return Arrays.asList(Period.values());
+    }
+    try {
+      return List.of(Period.valueOf(period.toUpperCase()));
+    } catch (IllegalArgumentException e) {
+      throw new DeokhugamException(ErrorCode.INVALID_PERIOD);
+    }
+  }
+
+  private ManualRankingBatchResult runJob(Period period, long requestedAt) {
+    try {
+      JobExecution execution = jobLauncher.run(rankingJob, new JobParametersBuilder()
+          .addString("period", period.name())
+          .addLong("requestedAt", requestedAt)
+          .toJobParameters());
+
+      BatchStatus status = execution.getStatus();
+      log.info("[ManualBatch] Ranking job completed. period={}, status={}, executionId={}",
+          period, status, execution.getId());
+      return new ManualRankingBatchResult(period, status.name(), execution.getId());
+    } catch (Exception e) {
+      log.error("[ManualBatch] Ranking job failed. period={}", period, e);
+      throw new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  public record ManualRankingBatchResponse(List<ManualRankingBatchResult> results) {
+  }
+
+  public record ManualRankingBatchResult(Period period, String status, Long executionId) {
+  }
+}

--- a/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/config/SecurityConfig.java
+++ b/deokhugam/src/main/java/com/deokhugam/deokhugam_server/global/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
             .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/books/popular").permitAll()
             .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/reviews/popular").permitAll()
             .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/users/power").permitAll()
+            .requestMatchers(org.springframework.http.HttpMethod.POST, "/internal/batches/ranking").permitAll()
 
             // 2. 스웨거(Swagger) 관련 경로들 - 문자열로 간단하게!
             .requestMatchers(

--- a/deokhugam/src/main/resources/application.yml
+++ b/deokhugam/src/main/resources/application.yml
@@ -33,6 +33,8 @@ deokhugam:
       cron: ${NOTIFICATION_CLEANUP_CRON:0 30 3 * * *}
     user-hard-delete:
       cron: ${USER_HARD_DELETE_CRON:0 30 4 * * *}
+    manual:
+      key: ${MANUAL_BATCH_KEY:}
   log:
     s3:
       enabled: ${S3_LOG_UPLOAD_ENABLED:false}

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListenerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/domain/notification/event/NotificationEventListenerTest.java
@@ -49,13 +49,13 @@ class NotificationEventListenerTest {
 
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
 
-    listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), commentAuthorId));
+    listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), commentAuthorId, "댓글작성자"));
 
     verify(notificationService).createNotification(
       eq(reviewId),
       eq(reviewOwnerId),
       eq(NotificationType.REVIEW_COMMENTED),
-      eq("회원님의 리뷰에 댓글이 달렸습니다.")
+      eq("댓글작성자님이 회원님의 리뷰에 댓글을 남겼습니다.")
     );
   }
 
@@ -67,13 +67,13 @@ class NotificationEventListenerTest {
     Review review = mockReview(ownerId);
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.of(review));
 
-    listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), ownerId));
+    listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), ownerId, "리뷰작성자"));
 
     verify(notificationService, never()).createNotification(
       eq(reviewId),
       eq(ownerId),
       eq(NotificationType.REVIEW_COMMENTED),
-      eq("회원님의 리뷰에 댓글이 달렸습니다.")
+      eq("리뷰작성자님이 회원님의 리뷰에 댓글을 남겼습니다.")
     );
   }
 
@@ -84,7 +84,8 @@ class NotificationEventListenerTest {
     given(reviewRepository.findByIdAndIsDeletedFalse(reviewId)).willReturn(Optional.empty());
 
     assertThatThrownBy(() ->
-      listener.handleCommentCreated(new CommentCreatedEvent(reviewId, UUID.randomUUID(), UUID.randomUUID())))
+      listener.handleCommentCreated(new CommentCreatedEvent(
+          reviewId, UUID.randomUUID(), UUID.randomUUID(), "댓글작성자")))
       .isInstanceOf(DeokhugamException.class)
       .hasMessageContaining(ErrorCode.REVIEW_NOT_FOUND.getMessage());
   }
@@ -96,13 +97,13 @@ class NotificationEventListenerTest {
     UUID likerId = UUID.randomUUID();
     UUID targetUserId = UUID.randomUUID();
 
-    listener.handleReviewLiked(new ReviewLikedEvent(reviewId, likerId, targetUserId, "리뷰 내용"));
+    listener.handleReviewLiked(new ReviewLikedEvent(reviewId, likerId, "좋아요작성자", targetUserId, "리뷰 내용"));
 
     verify(notificationService).createNotification(
       eq(reviewId),
       eq(targetUserId),
       eq(NotificationType.REVIEW_LIKED),
-      eq("회원님의 리뷰에 좋아요가 달렸습니다.")
+      eq("좋아요작성자님이 회원님의 리뷰에 좋아요를 눌렀습니다.")
     );
   }
 
@@ -111,7 +112,7 @@ class NotificationEventListenerTest {
   void handleReviewLiked_SkipSelfLike() {
     UUID userId = UUID.randomUUID();
 
-    listener.handleReviewLiked(new ReviewLikedEvent(UUID.randomUUID(), userId, userId, "리뷰 내용"));
+    listener.handleReviewLiked(new ReviewLikedEvent(UUID.randomUUID(), userId, "리뷰작성자", userId, "리뷰 내용"));
 
     verify(notificationService, never()).createNotification(
       org.mockito.ArgumentMatchers.any(),

--- a/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/batch/ManualRankingBatchControllerTest.java
+++ b/deokhugam/src/test/java/com/deokhugam/deokhugam_server/global/batch/ManualRankingBatchControllerTest.java
@@ -1,0 +1,135 @@
+package com.deokhugam.deokhugam_server.global.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.deokhugam.deokhugam_server.global.exception.DeokhugamException;
+import com.deokhugam.deokhugam_server.global.exception.ErrorCode;
+import com.deokhugam.deokhugam_server.global.type.Period;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ManualRankingBatchControllerTest {
+
+  private static final String MANUAL_BATCH_KEY = "test-manual-batch-key";
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job rankingJob;
+
+  private ManualRankingBatchController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new ManualRankingBatchController(jobLauncher, rankingJob);
+    ReflectionTestUtils.setField(controller, "manualBatchKey", MANUAL_BATCH_KEY);
+  }
+
+  @Test
+  @DisplayName("성공: 전체 기간 랭킹 배치를 실행한다")
+  void runRankingBatch_WithAllPeriod_LaunchesAllRankingJobs() throws Exception {
+    when(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+        .thenReturn(jobExecution(1L), jobExecution(2L), jobExecution(3L), jobExecution(4L));
+
+    ResponseEntity<ManualRankingBatchController.ManualRankingBatchResponse> response =
+        controller.runRankingBatch(MANUAL_BATCH_KEY, "ALL");
+
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().results())
+        .extracting(ManualRankingBatchController.ManualRankingBatchResult::period)
+        .containsExactly(Period.DAILY, Period.WEEKLY, Period.MONTHLY, Period.ALL_TIME);
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher, times(4)).run(any(Job.class), captor.capture());
+    List<String> periods = captor.getAllValues().stream()
+        .map(params -> params.getString("period"))
+        .toList();
+    assertThat(periods).containsExactly("DAILY", "WEEKLY", "MONTHLY", "ALL_TIME");
+  }
+
+  @Test
+  @DisplayName("성공: 지정한 기간 랭킹 배치만 실행한다")
+  void runRankingBatch_WithSinglePeriod_LaunchesRequestedRankingJob() throws Exception {
+    when(jobLauncher.run(any(Job.class), any(JobParameters.class))).thenReturn(jobExecution(10L));
+
+    ResponseEntity<ManualRankingBatchController.ManualRankingBatchResponse> response =
+        controller.runRankingBatch(MANUAL_BATCH_KEY, "weekly");
+
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().results()).hasSize(1);
+    assertThat(response.getBody().results().get(0).period()).isEqualTo(Period.WEEKLY);
+    assertThat(response.getBody().results().get(0).status()).isEqualTo(BatchStatus.COMPLETED.name());
+    assertThat(response.getBody().results().get(0).executionId()).isEqualTo(10L);
+
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(jobLauncher).run(any(Job.class), captor.capture());
+    assertThat(captor.getValue().getString("period")).isEqualTo("WEEKLY");
+  }
+
+  @Test
+  @DisplayName("실패: 수동 배치 키가 일치하지 않으면 접근을 거부한다")
+  void runRankingBatch_WithInvalidKey_ThrowsAccessDenied() {
+    assertThatThrownBy(() -> controller.runRankingBatch("invalid-key", "DAILY"))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.HANDLE_ACCESS_DENIED.getMessage());
+  }
+
+  @Test
+  @DisplayName("실패: 수동 배치 키가 설정되지 않으면 접근을 거부한다")
+  void runRankingBatch_WithBlankConfiguredKey_ThrowsAccessDenied() {
+    ReflectionTestUtils.setField(controller, "manualBatchKey", "");
+
+    assertThatThrownBy(() -> controller.runRankingBatch(MANUAL_BATCH_KEY, "DAILY"))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.HANDLE_ACCESS_DENIED.getMessage());
+  }
+
+  @Test
+  @DisplayName("실패: 지원하지 않는 기간이면 예외를 던진다")
+  void runRankingBatch_WithInvalidPeriod_ThrowsInvalidPeriod() {
+    assertThatThrownBy(() -> controller.runRankingBatch(MANUAL_BATCH_KEY, "YEARLY"))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.INVALID_PERIOD.getMessage());
+  }
+
+  @Test
+  @DisplayName("실패: 배치 실행 중 예외가 발생하면 서버 예외로 변환한다")
+  void runRankingBatch_WhenJobLaunchFails_ThrowsInternalServerError() throws Exception {
+    doThrow(new JobExecutionAlreadyRunningException("already running"))
+        .when(jobLauncher)
+        .run(any(Job.class), any(JobParameters.class));
+
+    assertThatThrownBy(() -> controller.runRankingBatch(MANUAL_BATCH_KEY, "DAILY"))
+        .isInstanceOf(DeokhugamException.class)
+        .hasMessage(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+  }
+
+  private JobExecution jobExecution(Long executionId) {
+    JobExecution execution = new JobExecution(executionId);
+    execution.setStatus(BatchStatus.COMPLETED);
+    return execution;
+  }
+}

--- a/task-definition.json
+++ b/task-definition.json
@@ -84,6 +84,10 @@
         {
           "name": "OCR_SPACE_API_KEY",
           "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:OCR_SPACE_API_KEY::"
+        },
+        {
+          "name": "MANUAL_BATCH_KEY",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:${AWS_ACCOUNT_ID}:secret:deokhugam/prod:MANUAL_BATCH_KEY::"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
## 🛠️ 작업 내용

### 🐛 버그 수정
- 댓글/좋아요 알림 메시지에서 행동 사용자명이 아닌 “회원님” 중심으로 표시되던 문제 수정

### ✨ 기능 추가 / 구현
- 운영 중 대시보드 랭킹 데이터를 즉시 재집계할 수 있는 수동 랭킹 배치 실행 API 추가
- `POST /internal/batches/ranking` 엔드포인트 추가
- `period=ALL|DAILY|WEEKLY|MONTHLY|ALL_TIME` 기준 선택 실행 지원
- `X-Internal-Batch-Key` 헤더 기반 내부 호출 검증 추가

### ♻️ 리팩토링
- 댓글 생성 이벤트에 댓글 작성자 닉네임 전달
- 리뷰 좋아요 이벤트에 좋아요 사용자 닉네임 전달
- 알림 생성 메시지에서 이벤트 행위자 정보를 사용하도록 정리

### ⚙️ 설정 변경
- 수동 배치 실행용 환경 변수 `MANUAL_BATCH_KEY` 추가
- 내부 배치 실행 API 보안 허용 경로 추가

## 🧪 테스트
- [x] 로컬 빌드 및 컴파일 성공 확인 (`./gradlew compileJava compileTestJava`)
- [x] 관련 단위 테스트 작성 및 통과 확인 (`./gradlew test --tests com.deokhugam.deokhugam_server.domain.notification.event.NotificationEventListenerTest`)
- [x] API 동작 확인 (Swagger 또는 직접 호출)

## ✅ 체크리스트
- [x] PR 제목 형식 확인: `[BE-RELEASE] 운영 배포 긴급 반영 v1.3.4`
- [x] `application-local.yml`, `.env` 등 민감 파일 미포함 확인
- [x] MapStruct / QueryDSL Q클래스 정상 생성 확인
- [x] Task Tracker의 GitHub PR 필드에 이 PR URL 기입
- [x] Task Tracker 상태를 **완료**로 변경

## 📎 참고 사항
- `release/v1.3.4`는 `main` 최신 기준으로 새로 분기하여 필요한 변경만 반영한 릴리즈 브랜치입니다.
- 배포 후 대시보드 데이터 보정이 필요한 경우 아래 API를 내부 키와 함께 호출해 랭킹을 수동 재집계할 수 있습니다.

```bash
POST /internal/batches/ranking?period=ALL
X-Internal-Batch-Key: <MANUAL_BATCH_KEY>
